### PR TITLE
(docs) - Add alt-text in details/summary for readme image

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,45 @@
 ![](/readme.svg)
+
+<details id="alt">
+  <summary>
+    Alt. Description
+  </summary>
+
+<div align="center">
+  <h2 align="center">Valtio</h2>
+  <p align="center"><code>npm i valtio</code> makes proxy-state simple</p>
+</div>
+
+### Wrap your state object
+
+```js
+import { proxy, useProxy } from 'valtio'
+
+const state = proxy({ count: 0, text: 'hello' })
+```
+
+### Mutate from anywhere
+
+```js
+setInterval(() => {
+  ++state.count
+}, 1000)
+```
+
+### React via `useProxy`
+
+```js
+function Counter() {
+  const snapshot = useProxy(state)
+  return (
+    <div>
+      {snapshot.count}
+      <button onClick={() => ++state.count}>+1</button>
+    </div>
+  )
+}
+```
+
+**And that's it!**
+
+</details>


### PR DESCRIPTION
Hiya :wave: Love the work that's gone into this! Especially since I suppose this had a lot of edge-cases to cover against suspense and concurrent mode 👏 

I'll keep this short. Basically I love the design of the readme image and how it show cases how simple and easy to use the API is. I just feel it'd be nice to include the alt. text for screen readers.

This can be made very unobstrusive if we just include a `<details>` spoiler. I tried labelling it by placing `aria-labelledby` on the image, however it seems that GitHub doesn't like this.

Anyway, awesome work!