### PR TITLE
vanilla support

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 5094,
-    "minified": 2272,
-    "gzipped": 973,
+    "bundled": 5109,
+    "minified": 2263,
+    "gzipped": 968,
     "treeshaked": {
       "rollup": {
         "code": 61,
@@ -14,19 +14,19 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 5844,
-    "minified": 2693,
-    "gzipped": 1068
+    "bundled": 5860,
+    "minified": 2681,
+    "gzipped": 1064
   },
   "index.iife.js": {
-    "bundled": 6218,
-    "minified": 2023,
+    "bundled": 6234,
+    "minified": 2007,
     "gzipped": 929
   },
   "vanilla.js": {
-    "bundled": 3492,
-    "minified": 1550,
-    "gzipped": 713,
+    "bundled": 3486,
+    "minified": 1544,
+    "gzipped": 710,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -38,8 +38,8 @@
     }
   },
   "vanilla.cjs.js": {
-    "bundled": 3988,
-    "minified": 1855,
-    "gzipped": 796
+    "bundled": 3983,
+    "minified": 1846,
+    "gzipped": 794
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 4798,
-    "minified": 2055,
-    "gzipped": 909,
+    "bundled": 5027,
+    "minified": 2248,
+    "gzipped": 957,
     "treeshaked": {
       "rollup": {
         "code": 61,
@@ -14,13 +14,32 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 5434,
-    "minified": 2404,
-    "gzipped": 995
+    "bundled": 5779,
+    "minified": 2669,
+    "gzipped": 1054
   },
   "index.iife.js": {
-    "bundled": 5780,
-    "minified": 1888,
-    "gzipped": 870
+    "bundled": 6151,
+    "minified": 1999,
+    "gzipped": 913
+  },
+  "vanilla.js": {
+    "bundled": 3425,
+    "minified": 1526,
+    "gzipped": 697,
+    "treeshaked": {
+      "rollup": {
+        "code": 22,
+        "import_statements": 22
+      },
+      "webpack": {
+        "code": 1045
+      }
+    }
+  },
+  "vanilla.cjs.js": {
+    "bundled": 3923,
+    "minified": 1831,
+    "gzipped": 782
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,32 +1,32 @@
 {
   "index.js": {
-    "bundled": 5109,
-    "minified": 2263,
-    "gzipped": 968,
+    "bundled": 4953,
+    "minified": 2186,
+    "gzipped": 944,
     "treeshaked": {
       "rollup": {
         "code": 61,
         "import_statements": 61
       },
       "webpack": {
-        "code": 1159
+        "code": 1171
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 5860,
-    "minified": 2681,
-    "gzipped": 1064
+    "bundled": 5664,
+    "minified": 2609,
+    "gzipped": 1047
   },
   "index.iife.js": {
-    "bundled": 6234,
-    "minified": 2007,
-    "gzipped": 929
+    "bundled": 6026,
+    "minified": 1972,
+    "gzipped": 909
   },
   "vanilla.js": {
-    "bundled": 3486,
-    "minified": 1544,
-    "gzipped": 710,
+    "bundled": 3180,
+    "minified": 1377,
+    "gzipped": 658,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -38,8 +38,8 @@
     }
   },
   "vanilla.cjs.js": {
-    "bundled": 3983,
-    "minified": 1846,
-    "gzipped": 794
+    "bundled": 3641,
+    "minified": 1664,
+    "gzipped": 741
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "valtio",
   "private": true,
   "version": "0.2.3",
-  "description": "💊 Valtio makes proxy-state simple ",
+  "description": "💊 Valtio makes proxy-state simple for React and Vanilla",
   "main": "index.cjs.js",
   "module": "index.js",
   "types": "index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -80,4 +80,6 @@ export default [
   createESMConfig('src/index.ts', 'dist/index.js'),
   createCommonJSConfig('src/index.ts', 'dist/index.cjs.js'),
   createIIFEConfig('src/index.ts', 'dist/index.iife.js', 'valtio'),
+  createESMConfig('src/vanilla.ts', 'dist/vanilla.js'),
+  createCommonJSConfig('src/vanilla.ts', 'dist/vanilla.cjs.js'),
 ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,136 +1,22 @@
 import { useMemo, useRef, useEffect } from 'react'
 
-import {
-  createDeepProxy,
-  isDeepChanged,
-  getUntrackedObject,
-} from 'proxy-compare'
+import { createDeepProxy, isDeepChanged } from 'proxy-compare'
 
 import { createMutableSource, useMutableSource } from './useMutableSource'
 
-const MUTABLE_SOURCE = Symbol()
-const LISTENERS = Symbol()
-const SNAPSHOT = Symbol()
+import { proxy, getMutableSource, subscribe, getSnapshot } from './vanilla'
 
-const isObject = (x: unknown): x is object =>
-  typeof x === 'object' && x !== null
-
-let globalVersion = 0
-const snapshotCache = new WeakMap<
-  object,
-  {
-    version: number
-    snapshot: unknown
-  }
->()
-
-const createProxy = <T extends object>(initialObject: T = {} as T): T => {
-  let version = globalVersion
-  let mutableSource: any
-  const listeners = new Set<(nextVersion?: number) => void>()
-  const notifyUpdate = (nextVersion?: number) => {
-    if (!nextVersion) {
-      nextVersion = ++globalVersion
-    }
-    if (version !== nextVersion) {
-      version = nextVersion
-      listeners.forEach((listener) => listener(nextVersion))
-    }
-  }
-  const proxy = new Proxy(Object.create(initialObject.constructor.prototype), {
-    get(target, prop, receiver) {
-      if (prop === MUTABLE_SOURCE) {
-        if (!mutableSource) {
-          mutableSource = createMutableSource(receiver, () => version)
-        }
-        return mutableSource
-      }
-      if (prop === LISTENERS) {
-        return listeners
-      }
-      if (prop === SNAPSHOT) {
-        const cache = snapshotCache.get(receiver)
-        if (cache && cache.version === version) {
-          return cache.snapshot
-        }
-        const snapshot = Object.create(target.constructor.prototype)
-        snapshotCache.set(receiver, { version, snapshot })
-        Reflect.ownKeys(target).forEach((key) => {
-          const value = target[key]
-          if (!isObject(value)) {
-            snapshot[key] = value
-          } else if (value instanceof Promise) {
-            Object.defineProperty(snapshot, key, {
-              get() {
-                throw value
-              },
-            })
-          } else {
-            snapshot[key] = (value as any)[SNAPSHOT]
-          }
-        })
-        return snapshot
-      }
-      return target[prop]
-    },
-    deleteProperty(target, prop) {
-      const value = target[prop]
-      const childListeners = isObject(value) && (value as any)[LISTENERS]
-      if (childListeners) {
-        childListeners.delete(notifyUpdate)
-      }
-      delete target[prop]
-      notifyUpdate()
-      return true
-    },
-    set(target, prop, value, receiver) {
-      const childListeners = isObject(target[prop]) && target[prop][LISTENERS]
-      if (childListeners) {
-        childListeners.delete(notifyUpdate)
-      }
-      if (!isObject(value)) {
-        target[prop] = value
-      } else if (value instanceof Promise) {
-        target[prop] = value.then((v) => {
-          receiver[prop] = v
-        })
-      } else {
-        value = getUntrackedObject(value) ?? value
-        if (value[LISTENERS]) {
-          target[prop] = value
-        } else {
-          target[prop] = createProxy(value)
-        }
-        target[prop][LISTENERS].add(notifyUpdate)
-      }
-      notifyUpdate()
-      return true
-    },
-  })
-  Reflect.ownKeys(initialObject).forEach((key) => {
-    proxy[key] = (initialObject as any)[key]
-  })
-  return proxy
-}
-
-const subscribe = (proxy: any, callback: () => void) => {
-  proxy[LISTENERS].add(callback)
-  return () => {
-    proxy[LISTENERS].delete(callback)
-  }
-}
-
-const useProxy = <T extends object>(proxy: T): T => {
+const useProxy = <T extends object>(p: T): T => {
   const affected = new WeakMap()
   const lastAffected = useRef<WeakMap<object, unknown>>()
   useEffect(() => {
     lastAffected.current = affected
   })
-  const getSnapshot = useMemo(() => {
+  const getChangedSnapshot = useMemo(() => {
     let prevSnapshot: any = null
     const deepChangedCache = new WeakMap()
-    return (proxy: any) => {
-      const snapshot = proxy[SNAPSHOT]
+    return (p: any) => {
+      const snapshot = getSnapshot(p)
       try {
         if (
           prevSnapshot !== null &&
@@ -152,12 +38,12 @@ const useProxy = <T extends object>(proxy: T): T => {
     }
   }, [])
   const snapshot = useMutableSource(
-    (proxy as any)[MUTABLE_SOURCE],
-    getSnapshot,
+    getMutableSource(p, createMutableSource),
+    getChangedSnapshot,
     subscribe
   )
   const proxyCache = useMemo(() => new WeakMap(), []) // per-hook proxyCache
   return createDeepProxy(snapshot, affected, proxyCache)
 }
 
-export { createProxy as proxy, useProxy, subscribe }
+export { proxy, subscribe, getSnapshot, useProxy }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,17 @@
 import { useMemo, useRef, useEffect } from 'react'
-
 import { createDeepProxy, isDeepChanged } from 'proxy-compare'
 
 import { createMutableSource, useMutableSource } from './useMutableSource'
+import { proxy, getVersion, subscribe, snapshot } from './vanilla'
 
-import { proxy, getMutableSource, subscribe, snapshot } from './vanilla'
+type MutableSource = any
+const mutableSourceCache = new WeakMap<object, MutableSource>()
+const getMutableSource = (p: any): MutableSource => {
+  if (!mutableSourceCache.has(p)) {
+    mutableSourceCache.set(p, createMutableSource(p, getVersion))
+  }
+  return mutableSourceCache.get(p) as MutableSource
+}
 
 const useProxy = <T extends object>(p: T): T => {
   const affected = new WeakMap()
@@ -38,7 +45,7 @@ const useProxy = <T extends object>(p: T): T => {
     }
   }, [])
   const currSnapshot = useMutableSource(
-    getMutableSource(p, createMutableSource),
+    getMutableSource(p),
     getChangedSnapshot,
     subscribe
   )

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -1,0 +1,129 @@
+import { getUntrackedObject } from 'proxy-compare'
+
+type MutableSource = any
+type CreateMutableSource = (p: any, getVersion: any) => MutableSource
+let createMutableSource: CreateMutableSource | undefined
+
+const MUTABLE_SOURCE = Symbol()
+const LISTENERS = Symbol()
+const SNAPSHOT = Symbol()
+
+const isObject = (x: unknown): x is object =>
+  typeof x === 'object' && x !== null
+
+let globalVersion = 0
+const snapshotCache = new WeakMap<
+  object,
+  {
+    version: number
+    snapshot: unknown
+  }
+>()
+
+export const proxy = <T extends object>(initialObject: T = {} as T): T => {
+  let version = globalVersion
+  let mutableSource: MutableSource | undefined
+  const listeners = new Set<(nextVersion?: number) => void>()
+  const notifyUpdate = (nextVersion?: number) => {
+    if (!nextVersion) {
+      nextVersion = ++globalVersion
+    }
+    if (version !== nextVersion) {
+      version = nextVersion
+      listeners.forEach((listener) => listener(nextVersion))
+    }
+  }
+  const p = new Proxy(Object.create(initialObject.constructor.prototype), {
+    get(target, prop, receiver) {
+      if (prop === MUTABLE_SOURCE) {
+        if (!mutableSource && createMutableSource) {
+          mutableSource = createMutableSource(receiver, () => version)
+        }
+        return mutableSource
+      }
+      if (prop === LISTENERS) {
+        return listeners
+      }
+      if (prop === SNAPSHOT) {
+        const cache = snapshotCache.get(receiver)
+        if (cache && cache.version === version) {
+          return cache.snapshot
+        }
+        const snapshot = Object.create(target.constructor.prototype)
+        snapshotCache.set(receiver, { version, snapshot })
+        Reflect.ownKeys(target).forEach((key) => {
+          const value = target[key]
+          if (!isObject(value)) {
+            snapshot[key] = value
+          } else if (value instanceof Promise) {
+            Object.defineProperty(snapshot, key, {
+              get() {
+                throw value
+              },
+            })
+          } else {
+            snapshot[key] = (value as any)[SNAPSHOT]
+          }
+        })
+        return snapshot
+      }
+      return target[prop]
+    },
+    deleteProperty(target, prop) {
+      const value = target[prop]
+      const childListeners = isObject(value) && (value as any)[LISTENERS]
+      if (childListeners) {
+        childListeners.delete(notifyUpdate)
+      }
+      delete target[prop]
+      notifyUpdate()
+      return true
+    },
+    set(target, prop, value, receiver) {
+      const childListeners = isObject(target[prop]) && target[prop][LISTENERS]
+      if (childListeners) {
+        childListeners.delete(notifyUpdate)
+      }
+      if (!isObject(value)) {
+        target[prop] = value
+      } else if (value instanceof Promise) {
+        target[prop] = value.then((v) => {
+          receiver[prop] = v
+        })
+      } else {
+        value = getUntrackedObject(value) ?? value
+        if (value[LISTENERS]) {
+          target[prop] = value
+        } else {
+          target[prop] = proxy(value)
+        }
+        target[prop][LISTENERS].add(notifyUpdate)
+      }
+      notifyUpdate()
+      return true
+    },
+  })
+  Reflect.ownKeys(initialObject).forEach((key) => {
+    p[key] = (initialObject as any)[key]
+  })
+  return p
+}
+
+export const getMutableSource = (
+  p: any,
+  fn: CreateMutableSource
+): MutableSource => {
+  if (!createMutableSource) {
+    createMutableSource = fn
+  }
+  return p[MUTABLE_SOURCE]
+}
+
+export const subscribe = (p: any, callback: () => void) => {
+  p[LISTENERS].add(callback)
+  return () => {
+    p[LISTENERS].delete(callback)
+  }
+}
+
+export const getSnapshot = <T extends object>(p: T): T => (p as any)[SNAPSHOT]

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -129,4 +129,4 @@ export const subscribe = (p: any, callback: () => void) => {
   }
 }
 
-export const getSnapshot = <T extends object>(p: T): T => (p as any)[SNAPSHOT]
+export const snapshot = <T extends object>(p: T): T => (p as any)[SNAPSHOT]


### PR DESCRIPTION
close #6 

Now, we should be able to do:
```js
import { proxy, subscribe, snapshot } from 'valtio/vanilla'
```

@chase-moskal 
Not sure how this works natively in browser. It still depends on proxy-compare and it needs to be adjusted too?