### PR TITLE
fix: array length for direct assignment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,10 @@ const createProxy = <T extends object>(initialObject: T = {} as T): T => {
       listeners.forEach((listener) => listener(nextVersion))
     }
   }
-  const proxy = new Proxy(Object.create(initialObject.constructor.prototype), {
+  const emptyCopy = Array.isArray(initialObject)
+    ? []
+    : Object.create(initialObject.constructor.prototype)
+  const proxy = new Proxy(emptyCopy, {
     get(target, prop, receiver) {
       if (prop === MUTABLE_SOURCE) {
         if (!mutableSource) {

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -139,7 +139,7 @@ it('array in object', async () => {
   await findByText('counts: 0,1,2,3')
 })
 
-it.only('array length after direct assignment', async () => {
+it('array length after direct assignment', async () => {
   const obj = proxy({ counts: [0, 1, 2] })
 
   const Counter: React.FC = () => {

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -139,6 +139,44 @@ it('array in object', async () => {
   await findByText('counts: 0,1,2,3')
 })
 
+it.only('array length after direct assignment', async () => {
+  const obj = proxy({ counts: [0, 1, 2] })
+
+  const Counter: React.FC = () => {
+    const snapshot = useProxy(obj)
+    return (
+      <>
+        <div>counts: {snapshot.counts.join(',')}</div>
+        <div>length: {snapshot.counts.length}</div>
+        <button
+          onClick={() => (obj.counts[obj.counts.length] = obj.counts.length)}>
+          increment
+        </button>
+        <button
+          onClick={() =>
+            (obj.counts[obj.counts.length + 5] = obj.counts.length + 5)
+          }>
+          jump
+        </button>
+      </>
+    )
+  }
+
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Counter />
+    </StrictMode>
+  )
+
+  await findByText('counts: 0,1,2')
+
+  fireEvent.click(getByText('increment'))
+  await findByText('counts: 0,1,2,3')
+
+  fireEvent.click(getByText('jump'))
+  await findByText('counts: 0,1,2,3,,,,,,9')
+})
+
 it('circular object', async () => {
   const obj = proxy<any>({ object: {} })
   obj.object = obj


### PR DESCRIPTION
Fixes #7 : array length not updating on index assignment.

It appears that creating an empty array using `Object.create` from the prototype of the original doesn't create a proper array, just an Object which inherits from the Array prototype. Real arrays have special behaviors.

See also https://stackoverflow.com/questions/22022058/new-array-vs-object-createarray-prototype

The added tests check for the special indexing properties of an Array: a simple case of adding a sequential item, and an edge case of adding a non-contiguous one.