### PR TITLE
Added tests for subscribe

### DIFF
--- a/tests/subscribe.test.tsx
+++ b/tests/subscribe.test.tsx
@@ -1,0 +1,75 @@
+import React, { StrictMode, useRef, useEffect } from 'react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { proxy, subscribe, useProxy } from '../src/index'
+
+describe('subscribe', () => {
+  it('should call subscription', () => {
+    const obj = proxy({ count: 0 })
+    const handler = jest.fn()
+
+    subscribe(obj, handler)
+
+    obj.count += 1
+
+    expect(handler).toBeCalledTimes(1)
+  })
+
+  it('should be able to unsubscribe', () => {
+    const obj = proxy({ count: 0 })
+    const handler = jest.fn()
+
+    const unsubscribe = subscribe(obj, handler)
+    unsubscribe()
+
+    obj.count += 1
+
+    expect(handler).toBeCalledTimes(0)
+  })
+
+  it('should call subscription of property', () => {
+    const obj = proxy({ count: 0 })
+    const handler = jest.fn()
+
+    subscribe(obj.count, handler)
+
+    obj.count += 1
+
+    expect(handler).toBeCalledTimes(1)
+  })
+
+  it('should call subscription of nested property', () => {
+    const obj = proxy({ nested: { count: 0 } })
+    const handler = jest.fn()
+
+    subscribe(obj.nested, handler)
+
+    obj.nested.count += 1
+
+    expect(handler).toBeCalledTimes(1)
+  })
+
+  it('should not re-run subscription if no change', () => {
+    const obj = proxy({ count: 0 })
+    const handler = jest.fn()
+
+    subscribe(obj, handler)
+
+    obj.count = 0
+
+    expect(handler).toBeCalledTimes(0)
+  })
+
+  it('should not cause infinite loop', () => {
+    const obj = proxy({ count: 0 })
+    const handler = () => {
+      // Reset count if above 5
+      if (obj.count > 5) {
+        obj.count = 0
+      }
+    }
+
+    subscribe(obj, handler)
+
+    obj.count = 10
+  })
+})


### PR DESCRIPTION
Hey! Thanks for the work on this library, I would like to contribute.

I have added tests for the `subscribe` function, and would also like to fix the non-working ones:

1. When you call `subscribe` on a non-object property (`count` in this case) it throws an `Cannot read property 'add' of undefined` error. I'm not quite sure how to go around fixing this, my guess is to do something like a createDeepProxy much earlier?

2. When you change the state inside a subscription, it calls the subscription again leading to a `Maximum call stack size exceeded` exception. I think this `isDeepChanged` needs to be moved to into `proxy` in vanilla?

Any pointers in the right direction? Thanks a lot!