### PR TITLE
fix: snapshots have to be plain objects

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 6043,
-    "minified": 2711,
-    "gzipped": 1123,
+    "bundled": 6284,
+    "minified": 2778,
+    "gzipped": 1138,
     "treeshaked": {
       "rollup": {
         "code": 61,
@@ -14,19 +14,19 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 6779,
-    "minified": 3129,
-    "gzipped": 1229
+    "bundled": 7026,
+    "minified": 3208,
+    "gzipped": 1252
   },
   "index.iife.js": {
-    "bundled": 7195,
-    "minified": 2395,
-    "gzipped": 1076
+    "bundled": 7458,
+    "minified": 2474,
+    "gzipped": 1105
   },
   "vanilla.js": {
-    "bundled": 4270,
-    "minified": 1902,
-    "gzipped": 835,
+    "bundled": 4511,
+    "minified": 1969,
+    "gzipped": 852,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -38,8 +38,8 @@
     }
   },
   "vanilla.cjs.js": {
-    "bundled": 4756,
-    "minified": 2184,
-    "gzipped": 934
+    "bundled": 5003,
+    "minified": 2263,
+    "gzipped": 955
   }
 }

--- a/tests/class.test.tsx
+++ b/tests/class.test.tsx
@@ -1,0 +1,104 @@
+import React, { StrictMode, useRef, useEffect } from 'react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { proxy, useProxy } from '../src/index'
+
+it('simple class without methods', async () => {
+  class CountClass {
+    public count: number
+    constructor() {
+      this.count = 0
+    }
+  }
+
+  const obj = proxy(new CountClass())
+
+  const Counter: React.FC = () => {
+    const snapshot = useProxy(obj)
+    return (
+      <>
+        <div>count: {snapshot.count}</div>
+        <button onClick={() => ++obj.count}>button</button>
+      </>
+    )
+  }
+
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Counter />
+    </StrictMode>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('button'))
+  await findByText('count: 1')
+})
+
+it('no extra re-renders with class', async () => {
+  class CountClass {
+    public count: number
+    public count2: number
+    constructor() {
+      this.count = 0
+      this.count2 = 0
+    }
+  }
+
+  const obj = proxy(new CountClass())
+
+  const Counter: React.FC = () => {
+    const snapshot = useProxy(obj)
+    const commitsRef = useRef(0)
+    useEffect(() => {
+      commitsRef.current += 1
+    })
+    return (
+      <>
+        <div>
+          count: {snapshot.count} ({commitsRef.current})
+        </div>
+        <button onClick={() => ++obj.count}>button</button>
+      </>
+    )
+  }
+
+  const Counter2: React.FC = () => {
+    const snapshot = useProxy(obj)
+    const commitsRef = useRef(0)
+    useEffect(() => {
+      commitsRef.current += 1
+    })
+    return (
+      <>
+        <div>
+          count2: {snapshot.count2} ({commitsRef.current})
+        </div>
+        <button onClick={() => ++obj.count2}>button2</button>
+      </>
+    )
+  }
+
+  const { getByText } = render(
+    <StrictMode>
+      <Counter />
+      <Counter2 />
+    </StrictMode>
+  )
+
+  await waitFor(() => {
+    getByText('count: 0 (0)')
+    getByText('count2: 0 (0)')
+  })
+
+  fireEvent.click(getByText('button'))
+  await waitFor(() => {
+    getByText('count: 1 (1)')
+    getByText('count2: 0 (0)')
+  })
+
+  fireEvent.click(getByText('button2'))
+  await waitFor(() => {
+    getByText('count: 1 (1)')
+    getByText('count2: 1 (1)')
+  })
+})

--- a/tests/class.test.tsx
+++ b/tests/class.test.tsx
@@ -142,7 +142,7 @@ it('inherited class without methods', async () => {
   await findByText('count: 1')
 })
 
-it('class with a class', async () => {
+it('class with a method', async () => {
   class CountClass {
     public count: number
     constructor() {

--- a/tests/class.test.tsx
+++ b/tests/class.test.tsx
@@ -102,3 +102,133 @@ it('no extra re-renders with class', async () => {
     getByText('count2: 1 (1)')
   })
 })
+
+it('inherited class without methods', async () => {
+  class BaseClass {
+    public count: number
+    constructor() {
+      this.count = 0
+    }
+  }
+  class CountClass extends BaseClass {
+    public count2: number
+    constructor() {
+      super()
+      this.count2 = 0
+    }
+  }
+
+  const obj = proxy(new CountClass())
+
+  const Counter: React.FC = () => {
+    const snapshot = useProxy(obj)
+    return (
+      <>
+        <div>count: {snapshot.count}</div>
+        <button onClick={() => ++obj.count}>button</button>
+      </>
+    )
+  }
+
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Counter />
+    </StrictMode>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('button'))
+  await findByText('count: 1')
+})
+
+it('class with a class', async () => {
+  class CountClass {
+    public count: number
+    constructor() {
+      this.count = 0
+    }
+    public doubled() {
+      return this.count * 2
+    }
+  }
+
+  const obj = proxy(new CountClass())
+
+  const Counter: React.FC = () => {
+    const snapshot = useProxy(obj)
+    return (
+      <>
+        <div>count: {snapshot.count}</div>
+        <div>doubled: {snapshot.doubled()}</div>
+        <button onClick={() => ++obj.count}>button</button>
+      </>
+    )
+  }
+
+  const { getByText } = render(
+    <StrictMode>
+      <Counter />
+    </StrictMode>
+  )
+
+  await waitFor(() => {
+    getByText('count: 0')
+    getByText('doubled: 0')
+  })
+
+  fireEvent.click(getByText('button'))
+  await waitFor(() => {
+    getByText('count: 1')
+    getByText('doubled: 2')
+  })
+})
+
+it('inherited class with a method', async () => {
+  class BaseClass {
+    public count: number
+    constructor() {
+      this.count = 0
+    }
+    public doubled() {
+      return this.count * 2
+    }
+  }
+  class CountClass extends BaseClass {
+    public count2: number
+    constructor() {
+      super()
+      this.count2 = 0
+    }
+  }
+
+  const obj = proxy(new CountClass())
+
+  const Counter: React.FC = () => {
+    const snapshot = useProxy(obj)
+    return (
+      <>
+        <div>count: {snapshot.count}</div>
+        <div>doubled: {snapshot.doubled()}</div>
+        <button onClick={() => ++obj.count}>button</button>
+      </>
+    )
+  }
+
+  const { getByText } = render(
+    <StrictMode>
+      <Counter />
+    </StrictMode>
+  )
+
+  await waitFor(() => {
+    getByText('count: 0')
+    getByText('doubled: 0')
+  })
+
+  fireEvent.click(getByText('button'))
+  await waitFor(() => {
+    getByText('count: 1')
+    getByText('doubled: 2')
+  })
+})


### PR DESCRIPTION
continuing from #24 

As of now, proxy-compare does only support plain objects and arrays, we can't use prototypes.
This is to work around by copying keys.

I'm not confident that test cases cover everything. Help wanted.