### PR TITLE
copy object getters in proxy

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 6380,
-    "minified": 3144,
-    "gzipped": 1205,
+    "bundled": 6546,
+    "minified": 3224,
+    "gzipped": 1227,
     "treeshaked": {
       "rollup": {
         "code": 61,
@@ -14,19 +14,19 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 7102,
-    "minified": 3558,
-    "gzipped": 1319
+    "bundled": 7266,
+    "minified": 3636,
+    "gzipped": 1345
   },
   "index.iife.js": {
-    "bundled": 7528,
-    "minified": 2798,
-    "gzipped": 1171
+    "bundled": 7702,
+    "minified": 2876,
+    "gzipped": 1199
   },
   "vanilla.js": {
-    "bundled": 4775,
-    "minified": 2470,
-    "gzipped": 921,
+    "bundled": 4941,
+    "minified": 2550,
+    "gzipped": 945,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -38,8 +38,8 @@
     }
   },
   "vanilla.cjs.js": {
-    "bundled": 5233,
-    "minified": 2739,
-    "gzipped": 1028
+    "bundled": 5397,
+    "minified": 2817,
+    "gzipped": 1054
   }
 }

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -135,8 +135,11 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
   })
   proxyCache.set(initialObject, p)
   Reflect.ownKeys(initialObject).forEach((key) => {
-    const desc = Object.getOwnPropertyDescriptor(initialObject, key)
-    if (desc && desc.get) {
+    const desc = Object.getOwnPropertyDescriptor(
+      initialObject,
+      key
+    ) as PropertyDescriptor
+    if (desc.get) {
       Object.defineProperty(baseObject, key, desc)
     } else {
       p[key] = (initialObject as any)[key]

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -46,10 +46,10 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
       listeners.forEach((listener) => listener(nextVersion as number))
     }
   }
-  const emptyCopy = Array.isArray(initialObject)
+  const baseObject = Array.isArray(initialObject)
     ? []
     : Object.create(Object.getPrototypeOf(initialObject))
-  const p = new Proxy(emptyCopy, {
+  const p = new Proxy(baseObject, {
     get(target, prop, receiver) {
       if (prop === VERSION) {
         return version
@@ -135,7 +135,12 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
   })
   proxyCache.set(initialObject, p)
   Reflect.ownKeys(initialObject).forEach((key) => {
-    p[key] = (initialObject as any)[key]
+    const desc = Object.getOwnPropertyDescriptor(initialObject, key)
+    if (desc && desc.get) {
+      Object.defineProperty(baseObject, key, desc)
+    } else {
+      p[key] = (initialObject as any)[key]
+    }
   })
   return p
 }


### PR DESCRIPTION
ref: https://github.com/pmndrs/valtio/pull/29#issuecomment-734229055

----
```tsx
const state1 = proxy({
  count: 0,
  get doubled() {
    return `doubled: ${this.count * 2} (${performance.now()})`;
  }
});

class StateClass {
  count = 0;
  get doubled() {
    return `doubled: ${this.count * 2} (${performance.now()})`;
  }
}
const state2 = proxy(new StateClass());

const Counter1: React.FC = () => {
  const snapshot = useProxy(state1);
  return (
    <div>
      <h4>Object runs the getter once</h4>
      {snapshot.doubled}
      <button onClick={() => ++state1.count}>+1</button>
    </div>
  );
};

const Counter2: React.FC = () => {
  const snapshot = useProxy(state2);
  return (
    <div>
      <h4>Class run the getter each</h4>
      {snapshot.doubled}
      <button onClick={() => ++state2.count}>+1</button>
    </div>
  );
};

const App: React.FC = () => (
  <div className="App">
    <Counter1 />
    <Counter1 />
    <Counter2 />
    <Counter2 />
  </div>
);
```

- object getters
  - computed at snapshot creation
  - not render optimized
- class getters
  - computed at render
  - render optimized
