### PR TITLE
Add subscribeKey Utility

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -43,9 +43,9 @@
     "gzipped": 1061
   },
   "utils.js": {
-    "bundled": 788,
-    "minified": 232,
-    "gzipped": 166,
+    "bundled": 1076,
+    "minified": 356,
+    "gzipped": 227,
     "treeshaked": {
       "rollup": {
         "code": 29,
@@ -57,8 +57,8 @@
     }
   },
   "utils.cjs.js": {
-    "bundled": 903,
-    "minified": 323,
-    "gzipped": 217
+    "bundled": 1230,
+    "minified": 477,
+    "gzipped": 272
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -43,9 +43,9 @@
     "gzipped": 1061
   },
   "utils.js": {
-    "bundled": 1076,
-    "minified": 356,
-    "gzipped": 227,
+    "bundled": 1453,
+    "minified": 352,
+    "gzipped": 225,
     "treeshaked": {
       "rollup": {
         "code": 29,
@@ -57,8 +57,8 @@
     }
   },
   "utils.cjs.js": {
-    "bundled": 1230,
-    "minified": 477,
-    "gzipped": 272
+    "bundled": 1607,
+    "minified": 473,
+    "gzipped": 268
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -49,9 +49,11 @@ import { subscribe } from 'valtio'
 const unsubscribe = subscribe(state, () => console.log('state has changed to', state))
 // Unsubscribe by calling the result
 unsubscribe()
-// Subscribe to a portion (object) of state
+// Subscribe to a portion of state
 subscribe(state.obj, () => console.log('state.obj has changed to', state.obj))
 ```
+
+To subscribe to a primitive value of state, consider [subscribeKey](./src/utils.ts#L28-L35) in utils.
 
 ##### Suspend your components
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,17 +24,26 @@ export const useLocalProxy = <T extends object>(init: T | (() => T)) => {
   return [useProxy(ref.current), ref.current] as const
 }
 
-export const subscribeKey = <TProxy extends unknown, TProperty>(
-  proxy: TProxy,
-  key: string,
-  callback: (val: TProperty) => void
+/**
+ * subscribeKey
+ *
+ * The subscribeKey utility enables subscription to a primitive subproperty of a given state proxy.
+ * Subscriptions created with subscribeKey will only fire when the specified property changes.
+ *
+ * @example
+ * import { subscribeKey } from 'valtio/utils'
+ * subscribeKey(state, 'count', (v) => console.log('state.count has changed to', v))
+ */
+export const subscribeKey = <T extends object>(
+  proxyObject: T,
+  key: keyof T,
+  callback: (val: T[typeof key]) => void
 ) => {
-  let prevValue = (proxy as any)[key]
-  return subscribe(proxy, () => {
-    const nextValue = (proxy as any)[key]
+  let prevValue = proxyObject[key]
+  return subscribe(proxyObject, () => {
+    const nextValue = proxyObject[key]
     if (!Object.is(prevValue, nextValue)) {
-      prevValue = nextValue
-      callback(nextValue)
+      callback((prevValue = nextValue))
     }
   })
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { useRef } from 'react'
-import { proxy, useProxy } from 'valtio'
+import { proxy, useProxy, subscribe } from 'valtio'
 
 /**
  * useLocalProxy
@@ -22,4 +22,19 @@ export const useLocalProxy = <T extends object>(init: T | (() => T)) => {
     ref.current = proxy(initialObject)
   }
   return [useProxy(ref.current), ref.current] as const
+}
+
+export const subscribeKey = <TProxy extends unknown, TProperty>(
+  proxy: TProxy,
+  key: string,
+  callback: (val: TProperty) => void
+) => {
+  let prevValue = (proxy as any)[key]
+  return subscribe(proxy, () => {
+    const nextValue = (proxy as any)[key]
+    if (!Object.is(prevValue, nextValue)) {
+      prevValue = nextValue
+      callback(nextValue)
+    }
+  })
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,7 @@ export const useLocalProxy = <T extends object>(init: T | (() => T)) => {
 export const subscribeKey = <T extends object>(
   proxyObject: T,
   key: keyof T,
-  callback: (val: T[typeof key]) => void
+  callback: (value: T[typeof key]) => void
 ) => {
   let prevValue = proxyObject[key]
   return subscribe(proxyObject, () => {


### PR DESCRIPTION
### `subscribeKey`

The `subscribeKey` utility enables subscription to a primitive subproperty of a given state proxy.
Subscriptions created with `subscribeKey` will only fire when the specified property changes.