### PR TITLE
fix: render from parents or something with uMS emulation hack

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const useProxy = <T extends object>(p: T): T => {
   useEffect(() => {
     lastAffected.current = affected
   })
-  const getChangedSnapshot = useMemo(() => {
+  const getSnapshot = useMemo(() => {
     let prevSnapshot: any = null
     const deepChangedCache = new WeakMap()
     return (p: any) => {
@@ -46,7 +46,7 @@ const useProxy = <T extends object>(p: T): T => {
   }, [])
   const currSnapshot = useMutableSource(
     getMutableSource(p),
-    getChangedSnapshot,
+    getSnapshot,
     subscribe
   )
   const proxyCache = useMemo(() => new WeakMap(), []) // per-hook proxyCache

--- a/src/useMutableSource.ts
+++ b/src/useMutableSource.ts
@@ -7,7 +7,7 @@ export {
 
 // emulation with use-subscription
 
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useSubscription } from 'use-subscription'
 
 const TARGET = Symbol()
@@ -39,5 +39,8 @@ export const useMutableSource = (
       }),
     [source, subscribe]
   )
+  useEffect(() => {
+    lastVersion.current = source[GET_VERSION](source[TARGET])
+  })
   return useSubscription({ getCurrentValue, subscribe: sub })
 }

--- a/src/useMutableSource.ts
+++ b/src/useMutableSource.ts
@@ -7,13 +7,15 @@ export {
 
 // emulation with use-subscription
 
-import { useMemo } from 'react'
+import { useCallback, useRef } from 'react'
 import { useSubscription } from 'use-subscription'
 
 const TARGET = Symbol()
+const GET_VERSION = Symbol()
 
-export const createMutableSource = (target: any, _getVersion: any) => ({
+export const createMutableSource = (target: any, getVersion: any) => ({
   [TARGET]: target,
+  [GET_VERSION]: getVersion,
 })
 
 export const useMutableSource = (
@@ -21,12 +23,21 @@ export const useMutableSource = (
   getSnapshot: any,
   subscribe: any
 ) => {
-  const subscription = useMemo(
-    () => ({
-      getCurrentValue: () => getSnapshot(source[TARGET]),
-      subscribe: (callback: () => void) => subscribe(source[TARGET], callback),
-    }),
-    [source, getSnapshot, subscribe]
+  const lastVersion = useRef(0)
+  const versionDiff = source[GET_VERSION](source[TARGET]) - lastVersion.current
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const getCurrentValue = useCallback(() => getSnapshot(source[TARGET]), [
+    source,
+    getSnapshot,
+    versionDiff, // XXX this is a hack
+  ])
+  const sub = useCallback(
+    (callback: () => void) =>
+      subscribe(source[TARGET], () => {
+        lastVersion.current = source[GET_VERSION](source[TARGET])
+        callback()
+      }),
+    [source, subscribe]
   )
-  return useSubscription(subscription)
+  return useSubscription({ getCurrentValue, subscribe: sub })
 }


### PR DESCRIPTION
ref #45 

This allows `forceUpdate` workaround.

Example:
```js
const state = proxy({ text: "hello" });

const TextBox = () => {
  const [, forceUpdate] = useReducer((c) => c + 1, 0);
  const snapshot = useProxy(state);
  const onChange = (e) => {
    state.text = e.target.value;
    forceUpdate();
  };
  return <input value={snapshot.text} onChange={onChange} />;
};
```
https://codesandbox.io/s/suspicious-darwin-dv99h