### PR TITLE
fix: better render invocation with scoped subscription

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 9945,
-    "minified": 4620,
-    "gzipped": 1704,
+    "bundled": 9994,
+    "minified": 4624,
+    "gzipped": 1698,
     "treeshaked": {
       "rollup": {
         "code": 137,
@@ -14,14 +14,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 10771,
-    "minified": 5080,
-    "gzipped": 1797
+    "bundled": 10855,
+    "minified": 5089,
+    "gzipped": 1800
   },
   "index.iife.js": {
-    "bundled": 11442,
-    "minified": 4045,
-    "gzipped": 1606
+    "bundled": 11534,
+    "minified": 4044,
+    "gzipped": 1602
   },
   "vanilla.js": {
     "bundled": 5470,


### PR DESCRIPTION
While I was working on #54, I noticed a slight unexpected behavior. A hook can call render function several times when another hook bails out.
Turns out we should use scope subscription instead. This PR fixes it and adds the test spec for the expected behavior.