### PR TITLE
Use useState instead of useRef in util

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -43,9 +43,9 @@
     "gzipped": 1118
   },
   "utils.js": {
-    "bundled": 3391,
-    "minified": 1141,
-    "gzipped": 645,
+    "bundled": 3356,
+    "minified": 1089,
+    "gzipped": 624,
     "treeshaked": {
       "rollup": {
         "code": 29,
@@ -57,8 +57,8 @@
     }
   },
   "utils.cjs.js": {
-    "bundled": 3620,
-    "minified": 1317,
-    "gzipped": 686
+    "bundled": 3677,
+    "minified": 1291,
+    "gzipped": 670
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useState } from 'react'
 import { proxy, useProxy, subscribe, snapshot } from 'valtio'
 
 /**
@@ -15,13 +15,10 @@ import { proxy, useProxy, subscribe, snapshot } from 'valtio'
  * [useImmer](https://github.com/immerjs/use-immer).
  */
 export const useLocalProxy = <T extends object>(init: T | (() => T)) => {
-  const ref = useRef<T>()
-  if (!ref.current) {
-    const initialObject =
-      typeof init === 'function' ? (init as () => T)() : init
-    ref.current = proxy(initialObject)
-  }
-  return [useProxy(ref.current), ref.current] as const
+  const [initialObject] = useState<T>(init)
+  const [initialObjectProxy] = useState<T>(() => proxy(initialObject))
+
+  return [useProxy(initialObjectProxy), initialObjectProxy] as const
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,8 +15,8 @@ import { proxy, useProxy, subscribe, snapshot } from 'valtio'
  * [useImmer](https://github.com/immerjs/use-immer).
  */
 export const useLocalProxy = <T extends object>(init: T | (() => T)) => {
-  const [initialObject] = useState<T>(init)
-  const [initialObjectProxy] = useState<T>(() => proxy(initialObject))
+  const [initialObject] = useState(init)
+  const [initialObjectProxy] = useState(() => proxy(initialObject))
 
   return [useProxy(initialObjectProxy), initialObjectProxy] as const
 }


### PR DESCRIPTION
Gives nothing, just
More readable (- 2 `if`s)
Less size (minified)
Uses "native" React mechanics to init something one time.