### PR TITLE
fix: do not reuse weak map and avoid lazy initialization

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 9994,
-    "minified": 4624,
-    "gzipped": 1698,
+    "bundled": 9899,
+    "minified": 4642,
+    "gzipped": 1702,
     "treeshaked": {
       "rollup": {
         "code": 137,
@@ -14,14 +14,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 10855,
-    "minified": 5089,
-    "gzipped": 1800
+    "bundled": 10745,
+    "minified": 5098,
+    "gzipped": 1803
   },
   "index.iife.js": {
-    "bundled": 11534,
-    "minified": 4044,
-    "gzipped": 1602
+    "bundled": 11416,
+    "minified": 4029,
+    "gzipped": 1604
   },
   "vanilla.js": {
     "bundled": 5470,


### PR DESCRIPTION
- do not reuse weak map for deepChangedCache (safer)
- useLayoutEffect instead of useRef lazy init (`p` can be changed, but it would re-render anyway)

I didn't see any actual issues, but they are theoretical issues.