### PR TITLE
Properly check for value for promise result

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 9899,
-    "minified": 4642,
-    "gzipped": 1702,
+    "bundled": 9901,
+    "minified": 4644,
+    "gzipped": 1706,
     "treeshaked": {
       "rollup": {
         "code": 137,
@@ -14,19 +14,19 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 10745,
-    "minified": 5098,
-    "gzipped": 1803
+    "bundled": 10747,
+    "minified": 5100,
+    "gzipped": 1807
   },
   "index.iife.js": {
-    "bundled": 11416,
-    "minified": 4029,
-    "gzipped": 1604
+    "bundled": 11418,
+    "minified": 4031,
+    "gzipped": 1606
   },
   "vanilla.js": {
-    "bundled": 5470,
-    "minified": 2750,
-    "gzipped": 1019,
+    "bundled": 5472,
+    "minified": 2752,
+    "gzipped": 1022,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -38,9 +38,9 @@
     }
   },
   "vanilla.cjs.js": {
-    "bundled": 5930,
-    "minified": 3025,
-    "gzipped": 1118
+    "bundled": 5932,
+    "minified": 3027,
+    "gzipped": 1122
   },
   "utils.js": {
     "bundled": 3391,

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -75,7 +75,7 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
           if (!isSupportedObject(value)) {
             snapshot[key] = value
           } else if (value instanceof Promise) {
-            if ((value as any)[PROMISE_RESULT]) {
+            if (PROMISE_RESULT in (value as any)) {
               snapshot[key] = (value as any)[PROMISE_RESULT]
             } else {
               const errorOrPromise = (value as any)[PROMISE_ERROR] || value

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -69,3 +69,34 @@ it('delayed object', async () => {
   await findByText('loading')
   await findByText('text: hello')
 })
+
+it('delayed falsy value', async () => {
+  const state = proxy<any>({ value: true })
+  const delayedValue = () => {
+    state.value = sleep(10).then(() => null)
+  }
+
+  const Counter: React.FC = () => {
+    const snapshot = useProxy(state)
+    return (
+      <>
+        <div>value: {String(snapshot.value)}</div>
+        <button onClick={delayedValue}>button</button>
+      </>
+    )
+  }
+
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </StrictMode>
+  )
+
+  await findByText('value: true')
+
+  fireEvent.click(getByText('button'))
+  await findByText('loading')
+  await findByText('value: null')
+})


### PR DESCRIPTION
Valtio currently does not work well with falsy values. This PR is a small improvement to allow falsy values to not be ignored.

Use case:
```js
const state = proxy({ user: user().catch(e => null) })
```