### PR TITLE
Add dependency order information for computeds of computeds

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,4 +191,12 @@ const state2 = proxyWithComputed({
     get: (snap) => snap.firstName + ' ' + snap.lastName,
     set: (state, newValue) => { [state.firstName, state.lastName] = newValue.split(' ') },
 })
+
+// if you want a computed value to derive from another computed, you must declare the dependency first:
+const state = proxyWithComputed({
+  count: 1,
+}, {
+  doubled: snap => snap.count * 2,
+  quadrupled: snap => snap.doubled * 2
+})
 ```


### PR DESCRIPTION
And it would be cool if eslint-plugin-valtio can warn about this too!