### PR TITLE
chore(tests): add simple tests for ref rerender and subscription

### DIFF
--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -367,5 +367,6 @@ it('should not trigger re-render when mutating object wrapped in ref', async () 
   await findByText('count: 0')
 
   fireEvent.click(getByText('button'))
+  await Promise.resolve()
   await findByText('count: 0')
 })

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,6 +1,6 @@
 import React, { StrictMode, useRef, useEffect, useState } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { proxy, useProxy } from '../src/index'
+import { proxy, ref, useProxy } from '../src/index'
 
 it('simple counter', async () => {
   const obj = proxy({ count: 0 })
@@ -343,4 +343,29 @@ it('render from outside', async () => {
   fireEvent.click(getByText('button'))
   fireEvent.click(getByText('toggle'))
   await findByText('count: 1')
+})
+
+it('should not trigger re-render when mutating object wrapped in ref', async () => {
+  const obj = proxy({ nested: ref({ count: 0 }) })
+
+  const Counter: React.FC = () => {
+    const snapshot = useProxy(obj)
+    return (
+      <>
+        <div>count: {snapshot.nested.count}</div>
+        <button onClick={() => ++obj.nested.count}>button</button>
+      </>
+    )
+  }
+
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Counter />
+    </StrictMode>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('button'))
+  await findByText('count: 0')
 })

--- a/tests/subscribe.test.tsx
+++ b/tests/subscribe.test.tsx
@@ -1,4 +1,4 @@
-import { proxy, subscribe } from '../src/index'
+import { proxy, ref, subscribe } from '../src/index'
 
 describe('subscribe', () => {
   it('should call subscription', async () => {
@@ -82,5 +82,17 @@ describe('subscribe', () => {
 
     await Promise.resolve()
     expect(handler).toBeCalledTimes(1)
+  })
+
+  it('should not call subscription for objects wrapped in ref', async () => {
+    const obj = proxy({ nested: ref({ count: 0 }) })
+    const handler = jest.fn()
+
+    subscribe(obj, handler)
+
+    obj.nested.count += 1
+
+    await Promise.resolve()
+    expect(handler).toBeCalledTimes(0)
   })
 })


### PR DESCRIPTION
Adds some simple tests for `ref` that was introduced in #62 and #65  fixes #66