### PR TITLE
Feat/nested computed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,4 +191,12 @@ const state2 = proxyWithComputed({
     get: (snap) => snap.firstName + ' ' + snap.lastName,
     set: (state, newValue) => { [state.firstName, state.lastName] = newValue.split(' ') },
 })
+
+// if you want a computed value to derive from another computed, you must declare the dependency first:
+const state = proxyWithComputed({
+  count: 1,
+}, {
+  doubled: snap => snap.count * 2,
+  quadrupled: snap => snap.doubled * 2
+})
 ```

--- a/readme.md
+++ b/readme.md
@@ -191,12 +191,4 @@ const state2 = proxyWithComputed({
     get: (snap) => snap.firstName + ' ' + snap.lastName,
     set: (state, newValue) => { [state.firstName, state.lastName] = newValue.split(' ') },
 })
-
-// if you want a computed value to derive from another computed, you must declare the dependency first:
-const state = proxyWithComputed({
-  count: 1,
-}, {
-  doubled: snap => snap.count * 2,
-  quadrupled: snap => snap.doubled * 2
-})
 ```

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,14 +155,14 @@ export const proxyWithComputed = <T extends object, U extends object>(
     const NOTIFIER = Symbol()
     Object.defineProperty(obj, NOTIFIER, { value: 0 })
     const notify = () => {
-      let loopP = proxyObject
-      let loopPath = path
-      while (loopPath.length > 0) {
-        const [first, ...rest] = loopPath
-        loopP = (loopP as any)[first]
-        loopPath = rest
+      let tmpProxy = proxyObject
+      let tmpPath = path
+      while (tmpPath.length > 0) {
+        const [first, ...rest] = tmpPath
+        tmpProxy = (tmpProxy as any)[first]
+        tmpPath = rest
       }
-      ++(loopP as any)[NOTIFIER]
+      ++(tmpProxy as any)[NOTIFIER]
     }
     const fnsKeys = Object.keys(fns) as (keyof typeof fns)[]
     fnsKeys.forEach((key, index) => {
@@ -204,15 +204,15 @@ export const proxyWithComputed = <T extends object, U extends object>(
                 })
             }
             prevSnapshot = snap
-            let loopS = snap
-            let loopPath = path
-            while (loopPath.length > 0) {
-              const [first, ...rest] = loopPath
-              loopS = (loopS as any)[first]
-              loopPath = rest
+            let tmpSnap = snap
+            let tmpPath = path
+            while (tmpPath.length > 0) {
+              const [first, ...rest] = tmpPath
+              tmpSnap = (tmpSnap as any)[first]
+              tmpPath = rest
             }
             if (computedValue instanceof Promise) {
-              Object.defineProperty(loopS, key, {
+              Object.defineProperty(tmpSnap, key, {
                 get() {
                   throw computedValue
                 },
@@ -221,16 +221,16 @@ export const proxyWithComputed = <T extends object, U extends object>(
               computedValue &&
               (computedValue as any)[COMPUTED_ERROR]
             ) {
-              Object.defineProperty(loopS, key, {
+              Object.defineProperty(tmpSnap, key, {
                 get() {
                   throw (computedValue as any)[COMPUTED_ERROR]
                 },
               })
             } else {
-              ;(loopS as any)[key] = computedValue
+              ;(tmpSnap as any)[key] = computedValue
             }
-            if (isLastItem && loopS !== snap) {
-              Object.freeze(loopS)
+            if (isLastItem && tmpSnap !== snap) {
+              Object.freeze(tmpSnap)
             }
           }
         })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -146,9 +146,9 @@ export const proxyWithComputed = <T extends object, U extends object>(
   initialObject: T,
   computedFns: ComputedFns<T, U>
 ) => {
-  const NOTIFIER = Symbol()
-  Object.defineProperty(initialObject, NOTIFIER, { value: 0 })
   const walk = <UU extends object>(obj: object, fns: ComputedFns<T, UU>) => {
+    const NOTIFIER = Symbol()
+    Object.defineProperty(obj, NOTIFIER, { value: 0 })
     ;(Object.keys(fns) as (keyof typeof fns)[]).forEach((key) => {
       const item = fns[key]
       if (!isComputedFn(item)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -164,7 +164,9 @@ export const proxyWithComputed = <T extends object, U extends object>(
       }
       ++(loopP as any)[NOTIFIER]
     }
-    ;(Object.keys(fns) as (keyof typeof fns)[]).forEach((key) => {
+    const fnsKeys = Object.keys(fns) as (keyof typeof fns)[]
+    fnsKeys.forEach((key, index) => {
+      const isLastItem = index === fnsKeys.length - 1
       const item = fns[key]
       if (!isComputedFn(item)) {
         const subObj = obj[key as keyof typeof obj]
@@ -227,6 +229,9 @@ export const proxyWithComputed = <T extends object, U extends object>(
             } else {
               ;(loopS as any)[key] = computedValue
             }
+            if (isLastItem && loopS !== snap) {
+              Object.freeze(loopS)
+            }
           }
         })
         return computedValue
@@ -250,6 +255,14 @@ export const proxyWithComputed = <T extends object, U extends object>(
     },
   })
   const proxyObject = proxy(initialObject) as T & U
+  subscribe(
+    proxyObject,
+    () => {
+      const snap = snapshot(proxyObject)
+      Object.freeze(snap)
+    },
+    true
+  )
   return proxyObject
 }
 

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -55,10 +55,53 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
       listeners.forEach((listener) => listener(nextVersion as number))
     }
   }
+  const createSnapshot = (target: any, receiver: any) => {
+    const cache = snapshotCache.get(receiver)
+    if (cache && cache.version === version) {
+      return cache.snapshot
+    }
+    const snapshot: any = Array.isArray(target)
+      ? []
+      : Object.create(Object.getPrototypeOf(target))
+    markToTrack(snapshot, true) // mark to track
+    snapshotCache.set(receiver, { version, snapshot })
+    let hasPropertyDescriptorGet = false
+    Reflect.ownKeys(target).forEach((key) => {
+      if (Object.getOwnPropertyDescriptor(target, key)?.get) {
+        hasPropertyDescriptorGet = true
+      }
+      const value = target[key]
+      if (refSet.has(value)) {
+        markToTrack(value, false) // mark not to track
+        snapshot[key] = value
+      } else if (!isSupportedObject(value)) {
+        snapshot[key] = value
+      } else if (value instanceof Promise) {
+        if (PROMISE_RESULT in (value as any)) {
+          snapshot[key] = (value as any)[PROMISE_RESULT]
+        } else {
+          const errorOrPromise = (value as any)[PROMISE_ERROR] || value
+          Object.defineProperty(snapshot, key, {
+            get() {
+              throw errorOrPromise
+            },
+          })
+        }
+      } else if ((value as any)[VERSION]) {
+        snapshot[key] = (value as any)[SNAPSHOT]
+      } else {
+        snapshot[key] = value
+      }
+    })
+    if (!hasPropertyDescriptorGet) {
+      Object.freeze(snapshot)
+    }
+    return snapshot
+  }
   const baseObject = Array.isArray(initialObject)
     ? []
     : Object.create(Object.getPrototypeOf(initialObject))
-  const p = new Proxy(baseObject, {
+  const proxyObject = new Proxy(baseObject, {
     get(target, prop, receiver) {
       if (prop === VERSION) {
         return version
@@ -67,46 +110,7 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
         return listeners
       }
       if (prop === SNAPSHOT) {
-        const cache = snapshotCache.get(receiver)
-        if (cache && cache.version === version) {
-          return cache.snapshot
-        }
-        const snapshot: any = Array.isArray(target)
-          ? []
-          : Object.create(Object.getPrototypeOf(target))
-        markToTrack(snapshot, true) // mark to track
-        snapshotCache.set(receiver, { version, snapshot })
-        Reflect.ownKeys(target).forEach((key) => {
-          const value = target[key]
-          if (refSet.has(value)) {
-            markToTrack(value, false) // mark not to track
-            snapshot[key] = value
-          } else if (!isSupportedObject(value)) {
-            snapshot[key] = value
-          } else if (value instanceof Promise) {
-            if (PROMISE_RESULT in (value as any)) {
-              snapshot[key] = (value as any)[PROMISE_RESULT]
-            } else {
-              const errorOrPromise = (value as any)[PROMISE_ERROR] || value
-              Object.defineProperty(snapshot, key, {
-                get() {
-                  throw errorOrPromise
-                },
-              })
-            }
-          } else if ((value as any)[VERSION]) {
-            snapshot[key] = (value as any)[SNAPSHOT]
-          } else {
-            snapshot[key] = value
-          }
-        })
-        if (
-          typeof process === 'object' &&
-          process.env.NODE_ENV !== 'production'
-        ) {
-          Object.freeze(snapshot)
-        }
-        return snapshot
+        return createSnapshot(target, receiver)
       }
       return target[prop]
     },
@@ -156,7 +160,7 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
       return true
     },
   })
-  proxyCache.set(initialObject, p)
+  proxyCache.set(initialObject, proxyObject)
   Reflect.ownKeys(initialObject).forEach((key) => {
     const desc = Object.getOwnPropertyDescriptor(
       initialObject,
@@ -165,32 +169,32 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
     if (desc.get) {
       Object.defineProperty(baseObject, key, desc)
     } else {
-      p[key] = (initialObject as any)[key]
+      proxyObject[key] = (initialObject as any)[key]
     }
   })
-  return p
+  return proxyObject
 }
 
-export const getVersion = (p: any): number => {
+export const getVersion = (proxyObject: any): number => {
   if (
     typeof process === 'object' &&
     process.env.NODE_ENV !== 'production' &&
-    (!p || !p[VERSION])
+    (!proxyObject || !proxyObject[VERSION])
   ) {
     throw new Error('Please use proxy object')
   }
-  return p[VERSION]
+  return proxyObject[VERSION]
 }
 
 export const subscribe = (
-  p: any,
+  proxyObject: any,
   callback: () => void,
   notifyInSync?: boolean
 ) => {
   if (
     typeof process === 'object' &&
     process.env.NODE_ENV !== 'production' &&
-    (!p || !p[LISTENERS])
+    (!proxyObject || !proxyObject[LISTENERS])
   ) {
     throw new Error('Please use proxy object')
   }
@@ -207,9 +211,9 @@ export const subscribe = (
       }
     })
   }
-  p[LISTENERS].add(listener)
+  proxyObject[LISTENERS].add(listener)
   return () => {
-    p[LISTENERS].delete(listener)
+    proxyObject[LISTENERS].delete(listener)
   }
 }
 
@@ -223,13 +227,13 @@ export type NonPromise<T> = T extends Function
     }
   : T
 
-export const snapshot = <T extends object>(p: T): NonPromise<T> => {
+export const snapshot = <T extends object>(proxyObject: T): NonPromise<T> => {
   if (
     typeof process === 'object' &&
     process.env.NODE_ENV !== 'production' &&
-    (!p || !(p as any)[SNAPSHOT])
+    (!proxyObject || !(proxyObject as any)[SNAPSHOT])
   ) {
     throw new Error('Please use proxy object')
   }
-  return (p as any)[SNAPSHOT]
+  return (proxyObject as any)[SNAPSHOT]
 }

--- a/tests/computed.test.tsx
+++ b/tests/computed.test.tsx
@@ -110,3 +110,48 @@ it('computed getters and setters', async () => {
   expect(snapshot(state)).toMatchObject({ text: 'a', count: 0.5, doubled: 1 })
   expect(computeDouble).toBeCalledTimes(3)
 })
+
+it('nested computed getters', async () => {
+  const computeDouble = jest.fn((x) => x * 2)
+  const state = proxyWithComputed<
+    {
+      text: string
+      math: { count: number }
+    },
+    {
+      math: { doubled: number }
+    }
+  >(
+    {
+      text: '',
+      math: { count: 0 },
+    },
+    {
+      math: {
+        doubled: (snap) => computeDouble(snap.math.count),
+      },
+    }
+  )
+
+  expect(snapshot(state)).toMatchObject({
+    text: '',
+    math: { count: 0, doubled: 0 },
+  })
+  expect(computeDouble).toBeCalledTimes(1)
+
+  state.math.count += 1
+  await Promise.resolve()
+  expect(snapshot(state)).toMatchObject({
+    text: '',
+    math: { count: 1, doubled: 2 },
+  })
+  expect(computeDouble).toBeCalledTimes(2)
+
+  state.text = 'a'
+  await Promise.resolve()
+  expect(snapshot(state)).toMatchObject({
+    text: 'a',
+    math: { count: 1, doubled: 2 },
+  })
+  expect(computeDouble).toBeCalledTimes(2)
+})


### PR DESCRIPTION
This is to implement nested computed proposed in #85.

- Core change: always freeze snapshot except for having object getters. Previously, it doesn't freeze in production. (This is more in line with immer v8.)
- Implement nested computed, fixes #85 
- Detect and error overwriting with computeds, resolves https://github.com/pmndrs/eslint-plugin-valtio/issues/5
- Some refactors