### PR TITLE
feat: addComputed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,4 +191,12 @@ const state2 = proxyWithComputed({
     get: (snap) => snap.firstName + ' ' + snap.lastName,
     set: (state, newValue) => { [state.firstName, state.lastName] = newValue.split(' ') },
 })
+
+// if you want a computed value to derive from another computed, you must declare the dependency first:
+const state = proxyWithComputed({
+  count: 1,
+}, {
+  doubled: snap => snap.count * 2,
+  quadrupled: snap => snap.doubled * 2
+})
 ```

--- a/readme.md
+++ b/readme.md
@@ -158,10 +158,46 @@ subscribe(state, () => {
 })
 ```
 
-#### Proxy with computed
+#### Computed values
 
-You can have computed values with dependency tracking. This is for experts.
-[Notes](./src/utils.ts#L121-L143)
+You can have computed values with dependency tracking.
+Dependency tracking in valtio conflicts with the work in useSnapshot.
+React users should consider using render functions (optionally useMemo)
+as a primary mean. Computed works well for some edge cases.
+
+##### `addComputed`
+
+This is to add new computed to an existing proxy state.
+It can add computed to different proxy state.
+
+```js
+import { addComputed } from 'valtio/utils'
+
+// create a base proxy
+const state = proxy({
+  count: 1,
+})
+
+// add computed to state
+addComputed(state, {
+  doubled: snap => snap.count * 2,
+})
+
+// create another proxy
+const state2 = proxy({
+  text: 'hello',
+})
+
+// add computed from state to state2
+addComputed(state, {
+  doubled: snap => snap.count * 2,
+}, state2)
+```
+
+##### `proxyWithComputed`
+
+This is to create a proxy state with computed at the same time.
+It can define setters optionally.
 
 ```js
 import { proxyWithComputed } from 'valtio/utils'

--- a/readme.md
+++ b/readme.md
@@ -191,12 +191,4 @@ const state2 = proxyWithComputed({
     get: (snap) => snap.firstName + ' ' + snap.lastName,
     set: (state, newValue) => { [state.firstName, state.lastName] = newValue.split(' ') },
 })
-
-// if you want a computed value to derive from another computed, you must declare the dependency first:
-const state = proxyWithComputed({
-  count: 1,
-}, {
-  doubled: snap => snap.count * 2,
-  quadrupled: snap => snap.doubled * 2
-})
 ```

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,6 +118,84 @@ export const devtools = <T extends object>(proxyObject: T, name?: string) => {
 }
 
 /**
+ * proxyWithComputed
+ *
+ * This is to create a proxy with initial object and additional object,
+ * which specifies getters for computed values with dependency tracking.
+ * It also accepts optional setters for computed values.
+ *
+ * [Notes]
+ * This is for expert users and not recommended for ordinary users.
+ * Contradictory to its name, this is costly and overlaps with useProxy.
+ * Do not try to optimize too early. It can worsen the performance.
+ * Measurement and comparison will be very important.
+ *
+ * @example
+ * import { proxyWithComputed } from 'valtio/utils'
+ * const state = proxyWithComputed({
+ *   count: 1,
+ * }, {
+ *   doubled: snap => snap.count * 2, // getter only
+ *   tripled: {
+ *     get: snap => snap.count * 3,
+ *     set: (state, newValue) => { state.count = newValue / 3 }
+ *   }, // with optional setter
+ * })
+ */
+export const proxyWithComputed = <T extends object, U extends object>(
+  initialObject: T,
+  computedFns: {
+    [K in keyof U]:
+      | ((snap: NonPromise<T>) => U[K])
+      | {
+          get: (snap: NonPromise<T>) => U[K]
+          set?: (state: T, newValue: U[K]) => void
+        }
+  }
+) => {
+  const NOTIFIER = Symbol()
+  Object.defineProperty(initialObject, NOTIFIER, { value: 0 })
+  ;(Object.keys(computedFns) as (keyof U)[]).forEach((key) => {
+    const computedFn = computedFns[key]
+    const { get, set } = (typeof computedFn === 'function'
+      ? { get: computedFn }
+      : computedFn) as {
+      get: (snap: NonPromise<T>) => U[typeof key]
+      set?: (state: T, newValue: U[typeof key]) => void
+    }
+    let computedValue: U[typeof key]
+    let prevSnapshot: NonPromise<T> | undefined
+    let affected = new WeakMap()
+    const desc: PropertyDescriptor = {}
+    desc.get = () => {
+      const nextSnapshot = snapshot(proxyObject)
+      if (
+        !prevSnapshot ||
+        isDeepChanged(prevSnapshot, nextSnapshot, affected)
+      ) {
+        affected = new WeakMap()
+        computedValue = get(createDeepProxy(nextSnapshot, affected))
+        if (computedValue instanceof Promise) {
+          computedValue.then((v) => {
+            computedValue = v
+            ++(proxyObject as any)[NOTIFIER] // HACK notify update
+          })
+          // XXX no error handling
+        }
+        prevSnapshot = nextSnapshot
+      }
+      return computedValue
+    }
+    if (set) {
+      desc.set = (newValue) => set(proxyObject, newValue)
+    }
+    Object.defineProperty(initialObject, key, desc)
+  })
+  const proxyObject = proxy(initialObject) as T & U
+  return proxyObject
+}
+
+/**
  * computed
  *
  * This creates a non-proxy object with computed values.
@@ -191,7 +269,7 @@ export const computed = <T extends object, U extends object>(
  *   }, // with optional setter
  * })
  */
-export const proxyWithComputed = <T extends object, U extends object>(
+export const proxyWithComputed2 = <T extends object, U extends object>(
   initialObject: T,
   computedFns: {
     [K in keyof U]:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,6 +118,80 @@ export const devtools = <T extends object>(proxyObject: T, name?: string) => {
 }
 
 /**
+ * addComputed
+ *
+ * This adds computed values to an existing proxy object.
+ *
+ * [Notes]
+ * This is for expert users and not recommended for ordinary users.
+ * Contradictory to its name, this is costly and overlaps with useSnapshot.
+ * Do not try to optimize too early. It can worsen the performance.
+ * Measurement and comparison will be very important.
+ *
+ * @example
+ * import { proxy } from 'valtio'
+ * import { addComputed } from 'valtio/utils'
+ * const state = proxy({
+ *   count: 1,
+ * })
+ * addComputed(state, {
+ *   doubled: snap => snap.count * 2,
+ * })
+ */
+export const addComputed = <T extends object, U extends object>(
+  proxyObject: T,
+  computedFns: {
+    [K in keyof U]: (snap: NonPromise<T>) => U[K]
+  },
+  targetObject: any = proxyObject
+) => {
+  ;(Object.keys(computedFns) as (keyof U)[]).forEach((key) => {
+    if (Object.getOwnPropertyDescriptor(targetObject, key)) {
+      throw new Error('object property already defined')
+    }
+    const get = computedFns[key]
+    let prevSnapshot: NonPromise<T> | undefined
+    let affected = new WeakMap()
+    let pending = false
+    const callback = () => {
+      const nextSnapshot = snapshot(proxyObject)
+      if (
+        !pending &&
+        (!prevSnapshot || isDeepChanged(prevSnapshot, nextSnapshot, affected))
+      ) {
+        affected = new WeakMap()
+        const value = get(createDeepProxy(nextSnapshot, affected))
+        prevSnapshot = nextSnapshot
+        if (value instanceof Promise) {
+          pending = true
+          value
+            .then((v) => {
+              targetObject[key] = v
+            })
+            .catch((e) => {
+              // not ideal but best effort for throwing error with proxy
+              targetObject[key] = new Proxy(
+                {},
+                {
+                  get() {
+                    throw e
+                  },
+                }
+              )
+            })
+            .finally(() => {
+              pending = false
+            })
+        }
+        targetObject[key] = value
+      }
+    }
+    subscribe(proxyObject, callback, true)
+    callback()
+  })
+}
+
+/**
  * proxyWithComputed
  *
  * This is to create a proxy with initial object and additional object,
@@ -153,8 +227,6 @@ export const proxyWithComputed = <T extends object, U extends object>(
         }
   }
 ) => {
-  const NOTIFIER = Symbol()
-  Object.defineProperty(initialObject, NOTIFIER, { value: 0 })
   ;(Object.keys(computedFns) as (keyof U)[]).forEach((key) => {
     if (Object.getOwnPropertyDescriptor(initialObject, key)) {
       throw new Error('object property already defined')
@@ -178,13 +250,6 @@ export const proxyWithComputed = <T extends object, U extends object>(
       ) {
         affected = new WeakMap()
         computedValue = get(createDeepProxy(nextSnapshot, affected))
-        if (computedValue instanceof Promise) {
-          computedValue.then((v) => {
-            computedValue = v
-            ++(proxyObject as any)[NOTIFIER] // HACK notify update
-          })
-          // XXX no error handling
-        }
         prevSnapshot = nextSnapshot
       }
       return computedValue
@@ -196,52 +261,4 @@ export const proxyWithComputed = <T extends object, U extends object>(
   })
   const proxyObject = proxy(initialObject) as T & U
   return proxyObject
-}
-
-/**
- * addComputed
- *
- * This adds computed values to an existing proxy object.
- */
-export const addComputed = <T extends object, U extends object>(
-  proxyObject: T,
-  computedFns: {
-    [K in keyof U]: (snap: NonPromise<T>) => U[K]
-  },
-  targetObject: any = proxyObject
-) => {
-  ;(Object.keys(computedFns) as (keyof U)[]).forEach((key) => {
-    if (Object.getOwnPropertyDescriptor(targetObject, key)) {
-      throw new Error('object property already defined')
-    }
-    const get = computedFns[key]
-    let prevSnapshot: NonPromise<T> | undefined
-    let affected = new WeakMap()
-    let pending = false
-    const callback = () => {
-      const nextSnapshot = snapshot(proxyObject)
-      if (
-        !pending &&
-        (!prevSnapshot || isDeepChanged(prevSnapshot, nextSnapshot, affected))
-      ) {
-        affected = new WeakMap()
-        const value = get(createDeepProxy(nextSnapshot, affected))
-        prevSnapshot = nextSnapshot
-        if (value instanceof Promise) {
-          pending = true
-          value
-            .then((v) => {
-              targetObject[key] = v
-            })
-            .finally(() => {
-              pending = false
-            })
-          // XXX no error handling
-        }
-        targetObject[key] = value
-      }
-    }
-    subscribe(proxyObject, callback, true)
-    callback()
-  })
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,14 +155,14 @@ export const proxyWithComputed = <T extends object, U extends object>(
     const NOTIFIER = Symbol()
     Object.defineProperty(obj, NOTIFIER, { value: 0 })
     const notify = () => {
-      let loopP = proxyObject
-      let loopPath = path
-      while (loopPath.length > 0) {
-        const [first, ...rest] = loopPath
-        loopP = (loopP as any)[first]
-        loopPath = rest
+      let tmpProxy = proxyObject
+      let tmpPath = path
+      while (tmpPath.length > 0) {
+        const [first, ...rest] = tmpPath
+        tmpProxy = (tmpProxy as any)[first]
+        tmpPath = rest
       }
-      ++(loopP as any)[NOTIFIER]
+      ++(tmpProxy as any)[NOTIFIER]
     }
     const fnsKeys = Object.keys(fns) as (keyof typeof fns)[]
     fnsKeys.forEach((key, index) => {
@@ -204,15 +204,15 @@ export const proxyWithComputed = <T extends object, U extends object>(
                 })
             }
             prevSnapshot = snap
-            let loopS = snap
-            let loopPath = path
-            while (loopPath.length > 0) {
-              const [first, ...rest] = loopPath
-              loopS = (loopS as any)[first]
-              loopPath = rest
+            let tmpSnap = snap
+            let tmpPath = path
+            while (tmpPath.length > 0) {
+              const [first, ...rest] = tmpPath
+              tmpSnap = (tmpSnap as any)[first]
+              tmpPath = rest
             }
             if (computedValue instanceof Promise) {
-              Object.defineProperty(loopS, key, {
+              Object.defineProperty(tmpSnap, key, {
                 get() {
                   throw computedValue
                 },
@@ -221,16 +221,16 @@ export const proxyWithComputed = <T extends object, U extends object>(
               computedValue &&
               (computedValue as any)[COMPUTED_ERROR]
             ) {
-              Object.defineProperty(loopS, key, {
+              Object.defineProperty(tmpSnap, key, {
                 get() {
                   throw (computedValue as any)[COMPUTED_ERROR]
                 },
               })
             } else {
-              ;(loopS as any)[key] = computedValue
+              ;(tmpSnap as any)[key] = computedValue
             }
-            if (isLastItem && loopS !== snap) {
-              Object.freeze(loopS)
+            if (isLastItem && tmpSnap !== snap) {
+              Object.freeze(tmpSnap)
             }
           }
         })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -146,9 +146,9 @@ export const proxyWithComputed = <T extends object, U extends object>(
   initialObject: T,
   computedFns: ComputedFns<T, U>
 ) => {
-  const NOTIFIER = Symbol()
-  Object.defineProperty(initialObject, NOTIFIER, { value: 0 })
   const walk = <UU extends object>(obj: object, fns: ComputedFns<T, UU>) => {
+    const NOTIFIER = Symbol()
+    Object.defineProperty(obj, NOTIFIER, { value: 0 })
     ;(Object.keys(fns) as (keyof typeof fns)[]).forEach((key) => {
       const item = fns[key]
       if (!isComputedFn(item)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -199,11 +199,11 @@ export const proxyWithComputed = <T extends object, U extends object>(
 }
 
 /**
- * attachComputed
+ * addComputed
  *
- * This attaches computed values to an existing proxy object.
+ * This adds computed values to an existing proxy object.
  */
-export const attachComputed = <T extends object, U extends object>(
+export const addComputed = <T extends object, U extends object>(
   proxyObject: T,
   computedFns: {
     [K in keyof U]: (snap: NonPromise<T>) => U[K]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -208,7 +208,7 @@ export const addComputed = <T extends object, U extends object>(
   computedFns: {
     [K in keyof U]: (snap: NonPromise<T>) => U[K]
   },
-  targetObject = proxyObject
+  targetObject: any = proxyObject
 ) => {
   ;(Object.keys(computedFns) as (keyof U)[]).forEach((key) => {
     if (Object.getOwnPropertyDescriptor(targetObject, key)) {
@@ -231,14 +231,14 @@ export const addComputed = <T extends object, U extends object>(
           pending = true
           value
             .then((v) => {
-              ;(targetObject as any)[key] = v
+              targetObject[key] = v
             })
             .finally(() => {
               pending = false
             })
           // XXX no error handling
         }
-        ;(targetObject as any)[key] = value
+        targetObject[key] = value
       }
     }
     subscribe(proxyObject, callback, true)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -164,7 +164,9 @@ export const proxyWithComputed = <T extends object, U extends object>(
       }
       ++(loopP as any)[NOTIFIER]
     }
-    ;(Object.keys(fns) as (keyof typeof fns)[]).forEach((key) => {
+    const fnsKeys = Object.keys(fns) as (keyof typeof fns)[]
+    fnsKeys.forEach((key, index) => {
+      const isLastItem = index === fnsKeys.length - 1
       const item = fns[key]
       if (!isComputedFn(item)) {
         const subObj = obj[key as keyof typeof obj]
@@ -227,6 +229,9 @@ export const proxyWithComputed = <T extends object, U extends object>(
             } else {
               ;(loopS as any)[key] = computedValue
             }
+            if (isLastItem && loopS !== snap) {
+              Object.freeze(loopS)
+            }
           }
         })
         return computedValue
@@ -250,6 +255,14 @@ export const proxyWithComputed = <T extends object, U extends object>(
     },
   })
   const proxyObject = proxy(initialObject) as T & U
+  subscribe(
+    proxyObject,
+    () => {
+      const snap = snapshot(proxyObject)
+      Object.freeze(snap)
+    },
+    true
+  )
   return proxyObject
 }
 

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -65,11 +65,7 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
       : Object.create(Object.getPrototypeOf(target))
     markToTrack(snapshot, true) // mark to track
     snapshotCache.set(receiver, { version, snapshot })
-    let hasPropertyDescriptorGet = false
     Reflect.ownKeys(target).forEach((key) => {
-      if (Object.getOwnPropertyDescriptor(target, key)?.get) {
-        hasPropertyDescriptorGet = true
-      }
       const value = target[key]
       if (refSet.has(value)) {
         markToTrack(value, false) // mark not to track
@@ -93,9 +89,7 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
         snapshot[key] = value
       }
     })
-    if (!hasPropertyDescriptorGet) {
-      Object.freeze(snapshot)
-    }
+    Object.freeze(snapshot)
     return snapshot
   }
   const baseObject = Array.isArray(initialObject)

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -55,10 +55,53 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
       listeners.forEach((listener) => listener(nextVersion as number))
     }
   }
+  const createSnapshot = (target: any, receiver: any) => {
+    const cache = snapshotCache.get(receiver)
+    if (cache && cache.version === version) {
+      return cache.snapshot
+    }
+    const snapshot: any = Array.isArray(target)
+      ? []
+      : Object.create(Object.getPrototypeOf(target))
+    markToTrack(snapshot, true) // mark to track
+    snapshotCache.set(receiver, { version, snapshot })
+    let hasPropertyDescriptorGet = false
+    Reflect.ownKeys(target).forEach((key) => {
+      if (Object.getOwnPropertyDescriptor(target, key)?.get) {
+        hasPropertyDescriptorGet = true
+      }
+      const value = target[key]
+      if (refSet.has(value)) {
+        markToTrack(value, false) // mark not to track
+        snapshot[key] = value
+      } else if (!isSupportedObject(value)) {
+        snapshot[key] = value
+      } else if (value instanceof Promise) {
+        if (PROMISE_RESULT in (value as any)) {
+          snapshot[key] = (value as any)[PROMISE_RESULT]
+        } else {
+          const errorOrPromise = (value as any)[PROMISE_ERROR] || value
+          Object.defineProperty(snapshot, key, {
+            get() {
+              throw errorOrPromise
+            },
+          })
+        }
+      } else if ((value as any)[VERSION]) {
+        snapshot[key] = (value as any)[SNAPSHOT]
+      } else {
+        snapshot[key] = value
+      }
+    })
+    if (!hasPropertyDescriptorGet) {
+      Object.freeze(snapshot)
+    }
+    return snapshot
+  }
   const baseObject = Array.isArray(initialObject)
     ? []
     : Object.create(Object.getPrototypeOf(initialObject))
-  const p = new Proxy(baseObject, {
+  const proxyObject = new Proxy(baseObject, {
     get(target, prop, receiver) {
       if (prop === VERSION) {
         return version
@@ -67,46 +110,7 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
         return listeners
       }
       if (prop === SNAPSHOT) {
-        const cache = snapshotCache.get(receiver)
-        if (cache && cache.version === version) {
-          return cache.snapshot
-        }
-        const snapshot: any = Array.isArray(target)
-          ? []
-          : Object.create(Object.getPrototypeOf(target))
-        markToTrack(snapshot, true) // mark to track
-        snapshotCache.set(receiver, { version, snapshot })
-        Reflect.ownKeys(target).forEach((key) => {
-          const value = target[key]
-          if (refSet.has(value)) {
-            markToTrack(value, false) // mark not to track
-            snapshot[key] = value
-          } else if (!isSupportedObject(value)) {
-            snapshot[key] = value
-          } else if (value instanceof Promise) {
-            if (PROMISE_RESULT in (value as any)) {
-              snapshot[key] = (value as any)[PROMISE_RESULT]
-            } else {
-              const errorOrPromise = (value as any)[PROMISE_ERROR] || value
-              Object.defineProperty(snapshot, key, {
-                get() {
-                  throw errorOrPromise
-                },
-              })
-            }
-          } else if ((value as any)[VERSION]) {
-            snapshot[key] = (value as any)[SNAPSHOT]
-          } else {
-            snapshot[key] = value
-          }
-        })
-        if (
-          typeof process === 'object' &&
-          process.env.NODE_ENV !== 'production'
-        ) {
-          Object.freeze(snapshot)
-        }
-        return snapshot
+        return createSnapshot(target, receiver)
       }
       return target[prop]
     },
@@ -156,7 +160,7 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
       return true
     },
   })
-  proxyCache.set(initialObject, p)
+  proxyCache.set(initialObject, proxyObject)
   Reflect.ownKeys(initialObject).forEach((key) => {
     const desc = Object.getOwnPropertyDescriptor(
       initialObject,
@@ -165,32 +169,32 @@ export const proxy = <T extends object>(initialObject: T = {} as T): T => {
     if (desc.get) {
       Object.defineProperty(baseObject, key, desc)
     } else {
-      p[key] = (initialObject as any)[key]
+      proxyObject[key] = (initialObject as any)[key]
     }
   })
-  return p
+  return proxyObject
 }
 
-export const getVersion = (p: any): number => {
+export const getVersion = (proxyObject: any): number => {
   if (
     typeof process === 'object' &&
     process.env.NODE_ENV !== 'production' &&
-    (!p || !p[VERSION])
+    (!proxyObject || !proxyObject[VERSION])
   ) {
     throw new Error('Please use proxy object')
   }
-  return p[VERSION]
+  return proxyObject[VERSION]
 }
 
 export const subscribe = (
-  p: any,
+  proxyObject: any,
   callback: () => void,
   notifyInSync?: boolean
 ) => {
   if (
     typeof process === 'object' &&
     process.env.NODE_ENV !== 'production' &&
-    (!p || !p[LISTENERS])
+    (!proxyObject || !proxyObject[LISTENERS])
   ) {
     throw new Error('Please use proxy object')
   }
@@ -207,9 +211,9 @@ export const subscribe = (
       }
     })
   }
-  p[LISTENERS].add(listener)
+  proxyObject[LISTENERS].add(listener)
   return () => {
-    p[LISTENERS].delete(listener)
+    proxyObject[LISTENERS].delete(listener)
   }
 }
 
@@ -223,13 +227,13 @@ export type NonPromise<T> = T extends Function
     }
   : T
 
-export const snapshot = <T extends object>(p: T): NonPromise<T> => {
+export const snapshot = <T extends object>(proxyObject: T): NonPromise<T> => {
   if (
     typeof process === 'object' &&
     process.env.NODE_ENV !== 'production' &&
-    (!p || !(p as any)[SNAPSHOT])
+    (!proxyObject || !(proxyObject as any)[SNAPSHOT])
   ) {
     throw new Error('Please use proxy object')
   }
-  return (p as any)[SNAPSHOT]
+  return (proxyObject as any)[SNAPSHOT]
 }

--- a/tests/computed.test.tsx
+++ b/tests/computed.test.tsx
@@ -110,3 +110,48 @@ it('computed getters and setters', async () => {
   expect(snapshot(state)).toMatchObject({ text: 'a', count: 0.5, doubled: 1 })
   expect(computeDouble).toBeCalledTimes(3)
 })
+
+it('nested computed getters', async () => {
+  const computeDouble = jest.fn((x) => x * 2)
+  const state = proxyWithComputed<
+    {
+      text: string
+      math: { count: number }
+    },
+    {
+      math: { doubled: number }
+    }
+  >(
+    {
+      text: '',
+      math: { count: 0 },
+    },
+    {
+      math: {
+        doubled: (snap) => computeDouble(snap.math.count),
+      },
+    }
+  )
+
+  expect(snapshot(state)).toMatchObject({
+    text: '',
+    math: { count: 0, doubled: 0 },
+  })
+  expect(computeDouble).toBeCalledTimes(1)
+
+  state.math.count += 1
+  await Promise.resolve()
+  expect(snapshot(state)).toMatchObject({
+    text: '',
+    math: { count: 1, doubled: 2 },
+  })
+  expect(computeDouble).toBeCalledTimes(2)
+
+  state.text = 'a'
+  await Promise.resolve()
+  expect(snapshot(state)).toMatchObject({
+    text: 'a',
+    math: { count: 1, doubled: 2 },
+  })
+  expect(computeDouble).toBeCalledTimes(2)
+})

--- a/tests/computed.test.tsx
+++ b/tests/computed.test.tsx
@@ -1,7 +1,7 @@
 import React, { StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import { useProxy, snapshot, subscribe } from '../src/index'
-import { proxyWithComputed } from '../src/utils'
+import { proxy, useProxy, snapshot, subscribe } from '../src/index'
+import { proxyWithComputed, attachComputed } from '../src/utils'
 
 const sleep = (ms: number) =>
   new Promise((resolve) => {
@@ -115,4 +115,73 @@ it('computed getters and setters', async () => {
   await Promise.resolve()
   expect(snapshot(state)).toMatchObject({ text: 'a', count: 0.5, doubled: 1 })
   expect(computeDouble).toBeCalledTimes(3)
+})
+
+it('simple attachComputed', async () => {
+  const computeDouble = jest.fn((x) => x * 2)
+  const state = proxy({
+    text: '',
+    count: 0,
+  })
+  attachComputed(state, {
+    doubled: (snap) => computeDouble(snap.count),
+  })
+
+  const callback = jest.fn()
+  subscribe(state, callback)
+
+  expect(snapshot(state)).toMatchObject({ text: '', count: 0, doubled: 0 })
+  expect(computeDouble).toBeCalledTimes(1)
+  expect(callback).toBeCalledTimes(0)
+
+  state.count += 1
+  await Promise.resolve()
+  expect(snapshot(state)).toMatchObject({ text: '', count: 1, doubled: 2 })
+  expect(computeDouble).toBeCalledTimes(2)
+  expect(callback).toBeCalledTimes(1)
+
+  state.text = 'a'
+  await Promise.resolve()
+  expect(snapshot(state)).toMatchObject({ text: 'a', count: 1, doubled: 2 })
+  expect(computeDouble).toBeCalledTimes(2)
+  expect(callback).toBeCalledTimes(2)
+})
+
+it('async attachComputed', async () => {
+  const state = proxy({ count: 0 })
+  attachComputed(state, {
+    delayedCount: async (snap) => {
+      await sleep(10)
+      return snap.count + 1
+    },
+  })
+
+  const Counter: React.FC = () => {
+    const snap = useProxy(
+      state as { count: number; delayedCount: Promise<number> }
+    )
+    return (
+      <>
+        <div>
+          count: {snap.count}, delayedCount: {snap.delayedCount}
+        </div>
+        <button onClick={() => ++state.count}>button</button>
+      </>
+    )
+  }
+
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Suspense fallback="loading">
+        <Counter />
+      </Suspense>
+    </StrictMode>
+  )
+
+  await findByText('loading')
+  await findByText('count: 0, delayedCount: 1')
+
+  fireEvent.click(getByText('button'))
+  await findByText('loading')
+  await findByText('count: 1, delayedCount: 2')
 })

--- a/tests/computed.test.tsx
+++ b/tests/computed.test.tsx
@@ -1,7 +1,7 @@
 import React, { StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { proxy, useProxy, snapshot, subscribe } from '../src/index'
-import { proxyWithComputed, attachComputed } from '../src/utils'
+import { proxyWithComputed, addComputed } from '../src/utils'
 
 const sleep = (ms: number) =>
   new Promise((resolve) => {
@@ -117,13 +117,13 @@ it('computed getters and setters', async () => {
   expect(computeDouble).toBeCalledTimes(3)
 })
 
-it('simple attachComputed', async () => {
+it('simple addComputed', async () => {
   const computeDouble = jest.fn((x) => x * 2)
   const state = proxy({
     text: '',
     count: 0,
   })
-  attachComputed(state, {
+  addComputed(state, {
     doubled: (snap) => computeDouble(snap.count),
   })
 
@@ -147,9 +147,9 @@ it('simple attachComputed', async () => {
   expect(callback).toBeCalledTimes(2)
 })
 
-it('async attachComputed', async () => {
+it('async addComputed', async () => {
   const state = proxy({ count: 0 })
-  attachComputed(state, {
+  addComputed(state, {
     delayedCount: async (snap) => {
       await sleep(10)
       return snap.count + 1

--- a/tests/computed.test.tsx
+++ b/tests/computed.test.tsx
@@ -40,47 +40,6 @@ it('simple computed getters', async () => {
   expect(callback).toBeCalledTimes(2)
 })
 
-it('async compute getters', async () => {
-  const state = proxyWithComputed(
-    { count: 0 },
-    {
-      delayedCount: {
-        get: async (snap) => {
-          await sleep(10)
-          return snap.count + 1
-        },
-      },
-    }
-  )
-
-  const Counter: React.FC = () => {
-    const snap = useSnapshot(state)
-    return (
-      <>
-        <div>
-          count: {snap.count}, delayedCount: {snap.delayedCount}
-        </div>
-        <button onClick={() => ++state.count}>button</button>
-      </>
-    )
-  }
-
-  const { getByText, findByText } = render(
-    <StrictMode>
-      <Suspense fallback="loading">
-        <Counter />
-      </Suspense>
-    </StrictMode>
-  )
-
-  await findByText('loading')
-  await findByText('count: 0, delayedCount: 1')
-
-  fireEvent.click(getByText('button'))
-  await findByText('loading')
-  await findByText('count: 1, delayedCount: 2')
-})
-
 it('computed getters and setters', async () => {
   const computeDouble = jest.fn((x) => x * 2)
   const state = proxyWithComputed(


### PR DESCRIPTION
#90 trial made me think that valtio's computed model is different from other libraries concepts.
`proxyWithComputed` works with object getters because it is the same proxy object.
We can't support addComputed and nested with the same way.
So, here we add a new `addComputed`. Unfortunately, we can't infer typing nicely.

This should close #85 and close #86.

----

We put `addComputed` at first and then `proxyWithComputed` in readme. addComputed supports async well and we drop (undocumented / experimental) async from proxyWithComputed. However, async in addComputed is still experimental and not documented.