### PR TITLE
Consider using relative imports

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.js": {
-    "bundled": 5830,
-    "minified": 2636,
-    "gzipped": 1075
+    "bundled": 11820,
+    "minified": 5431,
+    "gzipped": 1943
   },
   "vanilla.js": {
     "bundled": 6414,
@@ -10,21 +10,21 @@
     "gzipped": 1178
   },
   "utils.js": {
-    "bundled": 7924,
-    "minified": 2518,
-    "gzipped": 1088
+    "bundled": 19171,
+    "minified": 7452,
+    "gzipped": 2591
   },
   "index.module.js": {
-    "bundled": 5059,
-    "minified": 2146,
-    "gzipped": 944,
+    "bundled": 10831,
+    "minified": 4840,
+    "gzipped": 1838,
     "treeshaked": {
       "rollup": {
-        "code": 160,
-        "import_statements": 59
+        "code": 137,
+        "import_statements": 36
       },
       "webpack": {
-        "code": 1311
+        "code": 1301
       }
     }
   },
@@ -43,16 +43,16 @@
     }
   },
   "utils.module.js": {
-    "bundled": 7362,
-    "minified": 2133,
-    "gzipped": 1012,
+    "bundled": 17871,
+    "minified": 6778,
+    "gzipped": 2499,
     "treeshaked": {
       "rollup": {
-        "code": 74,
-        "import_statements": 74
+        "code": 137,
+        "import_statements": 36
       },
       "webpack": {
-        "code": 1157
+        "code": 1301
       }
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from 'valtio/vanilla'
+export * from './vanilla'
 export * from './react'

--- a/src/react.ts
+++ b/src/react.ts
@@ -13,7 +13,7 @@ import {
   affectedToPathList,
 } from 'proxy-compare'
 
-import { getVersion, subscribe, snapshot } from 'valtio/vanilla'
+import { getVersion, subscribe, snapshot } from './vanilla'
 import { createMutableSource, useMutableSource } from './useMutableSource'
 import type { NonPromise } from './vanilla'
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { useRef } from 'react'
-import { proxy, subscribe, snapshot } from 'valtio/vanilla'
-import { useProxy } from 'valtio'
+import { proxy, subscribe, snapshot } from './vanilla'
+import { useProxy } from '.'
 import { createDeepProxy, isDeepChanged } from 'proxy-compare'
 import type { NonPromise } from './vanilla'
 


### PR DESCRIPTION
Related to https://github.com/pmndrs/valtio/issues/110. Simply replaced `"valtio"` and `"valtio/vanilla"` imports with relative paths so it should make Valtio work with ES Modules CDNs (Snowpack/Skypack, JSDelivr/esm.run, esm.sh etc.) while they add support for/decide to not support named package submodules. 