### PR TITLE
fix: addComputed with array.pop() use case

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -167,7 +167,7 @@ export const addComputed = <T extends object, U extends object>(
         targetObject[key] = value
       }
     }
-    subscribe(proxyObject, callback, true)
+    subscribe(proxyObject, callback)
     callback()
   })
 }

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -223,6 +223,35 @@ it('array in object', async () => {
   await findByText('counts: 0,1,2,3')
 })
 
+it('array pop and splice', async () => {
+  const arr = proxy([0, 1, 2])
+
+  const Counter: React.FC = () => {
+    const snap = useSnapshot(arr)
+    return (
+      <>
+        <div>counts: {snap.join(',')}</div>
+        <button onClick={() => arr.pop()}>button</button>
+        <button onClick={() => arr.splice(1, 0, 10, 11)}>button2</button>
+      </>
+    )
+  }
+
+  const { getByText, findByText } = render(
+    <StrictMode>
+      <Counter />
+    </StrictMode>
+  )
+
+  await findByText('counts: 0,1,2')
+
+  fireEvent.click(getByText('button'))
+  await findByText('counts: 0,1')
+
+  fireEvent.click(getByText('button2'))
+  await findByText('counts: 0,10,11,1')
+})
+
 it('array length after direct assignment', async () => {
   const obj = proxy({ counts: [0, 1, 2] })
 

--- a/tests/computed.test.tsx
+++ b/tests/computed.test.tsx
@@ -224,3 +224,18 @@ it('nested emulation with addComputed', async () => {
   expect(computeDouble).toBeCalledTimes(2)
   expect(callback).toBeCalledTimes(2)
 })
+
+it('addComputed with array.pop (#124)', async () => {
+  const state = proxy({
+    arr: [1, 2, 3],
+  })
+  addComputed(state, {
+    doubled: (snap) => snap.arr.map((x) => x * 2),
+  })
+
+  expect(snapshot(state)).toMatchObject({ arr: [1, 2, 3], doubled: [2, 4, 6] })
+
+  state.arr.pop()
+  await Promise.resolve()
+  expect(snapshot(state)).toMatchObject({ arr: [1, 2], doubled: [2, 4] })
+})

--- a/tests/computed.test.tsx
+++ b/tests/computed.test.tsx
@@ -137,6 +137,7 @@ it('simple addComputed', async () => {
   await Promise.resolve()
   expect(snapshot(state)).toMatchObject({ text: '', count: 1, doubled: 2 })
   expect(computeDouble).toBeCalledTimes(2)
+  await Promise.resolve()
   expect(callback).toBeCalledTimes(1)
 
   state.text = 'a'
@@ -213,6 +214,7 @@ it('nested emulation with addComputed', async () => {
     math: { count: 1, doubled: 2 },
   })
   expect(computeDouble).toBeCalledTimes(2)
+  await Promise.resolve()
   expect(callback).toBeCalledTimes(1)
 
   state.text = 'a'

--- a/tests/computed.test.tsx
+++ b/tests/computed.test.tsx
@@ -227,15 +227,21 @@ it('nested emulation with addComputed', async () => {
 
 it('addComputed with array.pop (#124)', async () => {
   const state = proxy({
-    arr: [1, 2, 3],
+    arr: [{ n: 1 }, { n: 2 }, { n: 3 }],
   })
   addComputed(state, {
-    doubled: (snap) => snap.arr.map((x) => x * 2),
+    nums: (snap) => snap.arr.map((item) => item.n),
   })
 
-  expect(snapshot(state)).toMatchObject({ arr: [1, 2, 3], doubled: [2, 4, 6] })
+  expect(snapshot(state)).toMatchObject({
+    arr: [{ n: 1 }, { n: 2 }, { n: 3 }],
+    nums: [1, 2, 3],
+  })
 
   state.arr.pop()
   await Promise.resolve()
-  expect(snapshot(state)).toMatchObject({ arr: [1, 2], doubled: [2, 4] })
+  expect(snapshot(state)).toMatchObject({
+    arr: [{ n: 1 }, { n: 2 }],
+    nums: [1, 2],
+  })
 })


### PR DESCRIPTION
This PR fixes a weird behavior reported in #124.
Because addComputed runs in sync, it can run get function with incomplete snapshot.
We give up running it sync, and delay one tick. This is not ideal, but until we found a better solution, this should be a safer solution.

Please note again that `addComputed` and `proxyWithComputed` are often not recommended with useSnapshot in react. Consider deriving state in render function as a primary mean.