### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ setInterval(() => {
 Create a local snapshot that catches changes. Rule of thumb: read from snapshots, mutate the source. The component will only re-render when the parts of the state you access have changed, it is render-optimized.
 
 ```jsx
+// This will re-render on `state.count` change but not on `state.text` change
 function Counter() {
   const snap = useSnapshot(state)
   return (


### PR DESCRIPTION
> The component will only re-render when the parts of the state you access have changed, it is render-optimized

This is clear after re-reading but it was initially counter-intuitive when seeing this pattern for the first time. Coming from zustand, `useSnapshot(state)` is very close to `useStore(state => state)` so it was confusing.

I would add a sentence confirming that it excludes the parts of the state we don't access from the component.