### PR TITLE
fix(build): Hybrid package change for ESM and CJS support

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,11 @@
 {
   "packages": ["dist"],
-  "sandboxes": ["new", "react-typescript-react-ts"],
+  "sandboxes": [
+    "new",
+    "react-typescript-react-ts",
+    "simple-react-browserify-x9yni",
+    "simple-snowpack-react-o1gmx",
+    "react-parcel-onewf"
+  ],
   "node": "12"
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,46 +1,32 @@
 {
-  "index.js": {
-    "bundled": 5116,
-    "minified": 2566,
-    "gzipped": 1043
+  "macro.js": {
+    "bundled": 2592,
+    "minified": 1413,
+    "gzipped": 693
   },
-  "index.mjs": {
-    "bundled": 4603,
-    "minified": 2099,
-    "gzipped": 917,
-    "treeshaked": {
-      "rollup": {
-        "code": 169,
-        "import_statements": 59
-      },
-      "webpack": {
-        "code": 1320
-      }
-    }
+  "utils.js": {
+    "bundled": 8190,
+    "minified": 3870,
+    "gzipped": 1486
   },
   "vanilla.js": {
     "bundled": 7203,
     "minified": 3456,
     "gzipped": 1298
   },
-  "vanilla.mjs": {
-    "bundled": 6624,
-    "minified": 3127,
-    "gzipped": 1218,
+  "macro.mjs": {
+    "bundled": 1359,
+    "minified": 886,
+    "gzipped": 505,
     "treeshaked": {
       "rollup": {
-        "code": 22,
-        "import_statements": 22
+        "code": 822,
+        "import_statements": 153
       },
       "webpack": {
-        "code": 1087
+        "code": 1863
       }
     }
-  },
-  "utils.js": {
-    "bundled": 8190,
-    "minified": 3870,
-    "gzipped": 1486
   },
   "utils.mjs": {
     "bundled": 6916,
@@ -56,22 +42,36 @@
       }
     }
   },
-  "macro.js": {
-    "bundled": 2592,
-    "minified": 1413,
-    "gzipped": 693
-  },
-  "macro.mjs": {
-    "bundled": 1359,
-    "minified": 886,
-    "gzipped": 505,
+  "vanilla.mjs": {
+    "bundled": 6624,
+    "minified": 3127,
+    "gzipped": 1218,
     "treeshaked": {
       "rollup": {
-        "code": 822,
-        "import_statements": 153
+        "code": 22,
+        "import_statements": 22
       },
       "webpack": {
-        "code": 1863
+        "code": 1087
+      }
+    }
+  },
+  "index.js": {
+    "bundled": 5502,
+    "minified": 2876,
+    "gzipped": 1043
+  },
+  "index.mjs": {
+    "bundled": 4649,
+    "minified": 2139,
+    "gzipped": 925,
+    "treeshaked": {
+      "rollup": {
+        "code": 169,
+        "import_statements": 59
+      },
+      "webpack": {
+        "code": 1285
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,5 +1,10 @@
 {
   "index.js": {
+    "bundled": 5116,
+    "minified": 2566,
+    "gzipped": 1043
+  },
+  "index.mjs": {
     "bundled": 4603,
     "minified": 2099,
     "gzipped": 917,
@@ -14,6 +19,11 @@
     }
   },
   "vanilla.js": {
+    "bundled": 7203,
+    "minified": 3456,
+    "gzipped": 1298
+  },
+  "vanilla.mjs": {
     "bundled": 6624,
     "minified": 3127,
     "gzipped": 1218,
@@ -28,6 +38,11 @@
     }
   },
   "utils.js": {
+    "bundled": 8190,
+    "minified": 3870,
+    "gzipped": 1486
+  },
+  "utils.mjs": {
     "bundled": 6916,
     "minified": 3262,
     "gzipped": 1411,
@@ -42,6 +57,11 @@
     }
   },
   "macro.js": {
+    "bundled": 2592,
+    "minified": 1413,
+    "gzipped": 693
+  },
+  "macro.mjs": {
     "bundled": 1359,
     "minified": 886,
     "gzipped": 505,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.1.0",
   "description": "💊 Valtio makes proxy-state simple for React and Vanilla",
-  "main": "index.js",
+  "main": "./index.js",
   "module": "./esm/index.mjs",
   "types": "index.d.ts",
   "typesVersions": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.0",
   "description": "💊 Valtio makes proxy-state simple for React and Vanilla",
   "main": "index.js",
-  "module": "esm/index.js",
+  "module": "./esm/index.mjs",
   "types": "index.d.ts",
   "typesVersions": {
     "<4.0": {
@@ -20,26 +20,26 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./index.d.ts",
-      "module": "./esm/index.js",
-      "import": "./esm/index.js",
+      "module": "./esm/index.mjs",
+      "import": "./esm/index.mjs",
       "default": "./index.js"
     },
     "./vanilla": {
       "types": "./vanilla.d.ts",
-      "module": "./esm/vanilla.js",
-      "import": "./esm/vanilla.js",
+      "module": "./esm/vanilla.mjs",
+      "import": "./esm/vanilla.mjs",
       "default": "./vanilla.js"
     },
     "./utils": {
       "types": "./utils.d.ts",
-      "module": "./esm/utils.js",
-      "import": "./esm/utils.js",
+      "module": "./esm/utils.mjs",
+      "import": "./esm/utils.mjs",
       "default": "./utils.js"
     },
     "./macro": {
       "types": "./macro.d.ts",
-      "module": "./esm/macro.js",
-      "import": "./esm/macro.js",
+      "module": "./esm/macro.mjs",
+      "import": "./esm/macro.mjs",
       "default": "./macro.js"
     }
   },
@@ -62,7 +62,7 @@
     "test": "jest && jest --setupFiles ./tests/setNodeEnvProduction.ts",
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
-    "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
+    "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\" && shx echo '{\"type\":\"module\"}' > dist/esm/package.json && json -I -f dist/esm/package.json"
   },
   "prettier": {
     "semi": false,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "exports": {
     "./package.json": "./package.json",
+    "./": "./",
     ".": {
       "types": "./index.d.ts",
       "module": "./esm/index.mjs",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -77,12 +77,12 @@ export default function (args) {
     c = c.slice('config-'.length)
     return [
       createCommonJSConfig(`src/${c}.ts`, `dist/${c}.js`),
-      createESMConfig(`src/${c}.ts`, `dist/esm/${c}.js`),
+      createESMConfig(`src/${c}.ts`, `dist/esm/${c}.mjs`),
     ]
   }
   return [
     createDeclarationConfig('src/index.ts', 'dist'),
     createCommonJSConfig('src/index.ts', 'dist/index.js'),
-    createESMConfig('src/index.ts', 'dist/esm/index.js'),
+    createESMConfig('src/index.ts', 'dist/esm/index.mjs'),
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,8 @@
-export * from './vanilla'
-export * from './react'
+export { useSnapshot } from "./react"
+export {
+  ref,
+  proxy,
+  getVersion,
+  subscribe,
+  snapshot,
+} from "./vanilla"

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,6 @@
 // export * from "./vanilla"
 // export * from "./react"
 
+export { useSnapshot } from './react'
 
-export { useSnapshot } from "./react"
-
-export {
-  ref,
-  proxy,
-  getVersion,
-  subscribe,
-  snapshot,
-} from "./vanilla"
-
+export { ref, proxy, getVersion, subscribe, snapshot } from './vanilla'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
+/* 
+  Dynamic re-exports blocked to support snowpack ts re-export issues
+*/
+// export * from "./vanilla"
+// export * from "./react"
+
+
 export { useSnapshot } from "./react"
+
 export {
   ref,
   proxy,
@@ -6,3 +14,4 @@ export {
   subscribe,
   snapshot,
 } from "./vanilla"
+


### PR DESCRIPTION
- Replicates: https://github.com/pmndrs/zustand/pull/507
- Attempts to fix:  https://github.com/pmndrs/valtio/issues/179


Browserify Working Example : https://codesandbox.io/s/react-browserify-forked-2ikqw?file=/src/index.js (Since the generated template isn't updated to work properly)

Working Snowpack Example: https://codesandbox.io/s/react-snowpack-forked-nq77c?file=/src/index.jsx for the attempted fix.

