### PR TITLE
refactor(core): useMutableSource emulation without symbol and any

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,15 +1,15 @@
 {
   "index.js": {
-    "bundled": 4649,
-    "minified": 2139,
-    "gzipped": 925,
+    "bundled": 4648,
+    "minified": 2112,
+    "gzipped": 923,
     "treeshaked": {
       "rollup": {
         "code": 169,
         "import_statements": 59
       },
       "webpack": {
-        "code": 1285
+        "code": 1267
       }
     }
   },

--- a/src/useMutableSource.ts
+++ b/src/useMutableSource.ts
@@ -9,20 +9,28 @@ export {
 
 import { useEffect, useRef, useState } from 'react'
 
-const TARGET = Symbol()
-const GET_VERSION = Symbol()
+const TARGET = '_uMS_T'
+const GET_VERSION = '_uMS_V'
 
-export const createMutableSource = (target: any, getVersion: any): any => ({
+type MutableSource<T, V> = {
+  [TARGET]: T
+  [GET_VERSION]: (target: T) => V
+}
+
+export const createMutableSource = <T, V>(
+  target: T,
+  getVersion: (target: T) => V
+): MutableSource<T, V> => ({
   [TARGET]: target,
   [GET_VERSION]: getVersion,
 })
 
-export const useMutableSource = (
-  source: any,
-  getSnapshot: any,
-  subscribe: any
+export const useMutableSource = <T, V, S>(
+  source: MutableSource<T, V>,
+  getSnapshot: (target: T) => S,
+  subscribe: (target: T, callback: () => void) => () => void
 ) => {
-  const lastVersion = useRef(0)
+  const lastVersion = useRef<V>()
   const currentVersion = source[GET_VERSION](source[TARGET])
   const [state, setState] = useState(
     () =>


### PR DESCRIPTION
We use hopefully unique strings instead of symbols.
This allows to avoid `any` type.