### PR TITLE
fix(core): expose canProxy in handler

### DIFF
--- a/src/utils/derive.ts
+++ b/src/utils/derive.ts
@@ -114,7 +114,7 @@ export const derive = <T extends object, U extends object>(
       }
       const dependencies = new Map<object, number>()
       const get = <P extends object>(p: P) => {
-        dependencies.set(p, getVersion(p))
+        dependencies.set(p, getVersion(p) as number)
         return p
       }
       const value = fn(get)

--- a/tests/subscribe.test.tsx
+++ b/tests/subscribe.test.tsx
@@ -56,7 +56,7 @@ describe('subscribe', () => {
     const obj = proxy({ count: 0 })
     const handler = jest.fn()
 
-    expect(() => subscribe(obj.count, handler)).toThrow()
+    expect(() => subscribe(obj.count as any, handler)).toThrow()
   })
 
   it('should not re-run subscription if no change', async () => {


### PR DESCRIPTION
Now, we can have more control on what to proxy and what not to proxy.
It's tricky to use `unstable_getHanlder`. It's for expert users for now.

This includes some refactors too.