### PR TITLE
fix: avoid const enum and deprecate DeepResolveType

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -22,6 +22,7 @@ module.exports = (api, targets) => {
           runtime: 'automatic',
         },
       ],
+      ['@babel/plugin-transform-typescript', { isTSX: true }],
     ],
   }
 }

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@babel/core": "^7.16.7",
     "@babel/helper-module-imports": "^7.16.7",
     "@babel/plugin-transform-react-jsx": "^7.16.7",
+    "@babel/plugin-transform-typescript": "^7.16.8",
     "@babel/preset-env": "^7.16.8",
     "@babel/types": "^7.16.8",
     "@rollup/plugin-alias": "^3.1.9",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -81,7 +81,6 @@ function createCommonJSConfig(input, output) {
         },
       }),
       resolve({ extensions }),
-      typescript(),
       babelPlugin(getBabelOptions({ ie: 11 })),
     ],
   }
@@ -105,7 +104,6 @@ function createUMDConfig(input, output) {
         },
       }),
       resolve({ extensions }),
-      typescript(),
       babelPlugin(getBabelOptions({ ie: 11 })),
     ],
   }
@@ -128,7 +126,6 @@ function createSystemConfig(input, output) {
         },
       }),
       resolve({ extensions }),
-      typescript(),
       getEsbuild('node12'),
     ],
   }

--- a/src/react.ts
+++ b/src/react.ts
@@ -14,7 +14,13 @@ import {
 } from 'proxy-compare'
 import { createMutableSource, useMutableSource } from './useMutableSource'
 import { getVersion, snapshot, subscribe } from './vanilla'
-import type { DeepResolveType } from './vanilla'
+
+class SnapshotWrapper<T extends object> {
+  fn(p: T) {
+    return snapshot(p)
+  }
+}
+type Snapshot<T extends object> = ReturnType<SnapshotWrapper<T>['fn']>
 
 const isSSR =
   typeof window === 'undefined' ||
@@ -127,12 +133,12 @@ type Options = {
 export const useSnapshot = <T extends object>(
   proxyObject: T,
   options?: Options
-): DeepResolveType<T> => {
+): Snapshot<T> => {
   const forceUpdate = useReducer((c) => c + 1, 0)[1]
   const affected = new WeakMap()
   const lastAffected = useRef<typeof affected>()
-  const prevSnapshot = useRef<DeepResolveType<T>>()
-  const lastSnapshot = useRef<DeepResolveType<T>>()
+  const prevSnapshot = useRef<Snapshot<T>>()
+  const lastSnapshot = useRef<Snapshot<T>>()
   useIsomorphicLayoutEffect(() => {
     lastSnapshot.current = prevSnapshot.current = snapshot(proxyObject)
   }, [proxyObject])

--- a/yarn.lock
+++ b/yarn.lock
@@ -528,7 +528,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.7.2":
+"@babel/plugin-syntax-typescript@^7.16.7", "@babel/plugin-syntax-typescript@^7.7.2":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.7.tgz#39c9b55ee153151990fb038651d58d3fd03f98f8"
   integrity sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==
@@ -780,6 +780,15 @@
   integrity sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
+
+"@babel/plugin-transform-typescript@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz#591ce9b6b83504903fa9dd3652c357c2ba7a1ee0"
+  integrity sha512-bHdQ9k7YpBDO2d0NVfkj51DpQcvwIzIusJ7mEUaMlbZq3Kt/U47j24inXZHQ5MDiYpCs+oZiwnXyKedE8+q7AQ==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-typescript" "^7.16.7"
 
 "@babel/plugin-transform-unicode-escapes@^7.16.7":
   version "7.16.7"


### PR DESCRIPTION
ref: https://github.com/pmndrs/valtio/issues/327#issuecomment-1018306353
close #292

`AsRef` const enum was introduced in #146 to fix some typing issue with snapshot. But, this causes some trouble while explicitly typing it, without any workarounds.

This changes `AsRef` to be _hopefully unique_ type. This allows types to be inferred. While we don't recommend, you can define the same `AsRef` on your end. It was our strong hope to hide the internal type as implementation detail and it's finally possible.

`DeepResolveType` was exported previously (which is not considered a public api, but someone might have used it), but it's now deprecated.

## Migration Guide

In case you need to specify snapshot types, there are two options.

### Assert mutable (let's lie)

```ts
type State = { foo?: string }
const state = proxy<State>({})

  const snap = useSnapshot(state) as State
  const handleSnap = (s: State) => {
    // ...
  }
```

### Wrap types with `Readonly<>`

```ts
type State = { foo?: string }
const state = proxy<State>({})

  const snap = useSnapshot(state)
  const handleSnap = (s: Readonly<State>) => {
    // ...
  }
```

If the state is deeply nested, please define `DeepReadonly` type util.
```ts
type DeepReadonly<T> = {
  readonly [P in keyof T]: DeepReadonly<T[P]>;
}

  const handleSnap = (s: DeepReadonly<State>) => {
    // ...
  }
```

### Other hacks

[Extract the return type of `snapshot`](https://github.com/pmndrs/valtio/blob/1034f3f5c36ae6feba7c8dbee3fbf2a96939d4ed/src/react.ts#L18-L23)
