### PR TITLE
fix(utils): make derive glitch free

### DIFF
--- a/src/utils/derive.ts
+++ b/src/utils/derive.ts
@@ -2,10 +2,12 @@ import { getVersion, proxy, subscribe } from '../vanilla'
 
 type DeriveGet = <T extends object>(proxyObject: T) => T
 
-type Subscriptions<U extends object> = Map<
-  object,
-  [callbackMap: Map<keyof U, () => void>, unsubscribe: () => void]
->
+type Subscription<U extends object> = [
+  callbackMap: Map<keyof U, () => void>,
+  unsubscribe: () => void
+]
+
+type Subscriptions<U extends object> = Map<object, Subscription<U>>
 
 const subscriptionsCache = new WeakMap<object, Subscriptions<object>>()
 
@@ -23,6 +25,25 @@ const getSubscriptions = (proxyObject: object) => {
 // changed or removed without any notice in future versions.
 // It's not expected to use this in production.
 export const unstable_getDeriveSubscriptions = getSubscriptions
+
+// to make derive glitch free
+const pendingCountMap = new WeakMap<object, number>()
+const markPending = (proxyObject: object) => {
+  const count = pendingCountMap.get(proxyObject) || 0
+  pendingCountMap.set(proxyObject, count + 1)
+  return () => {
+    const count = pendingCountMap.get(proxyObject) || 0
+    if (count > 1) {
+      pendingCountMap.set(proxyObject, count - 1)
+    } else {
+      pendingCountMap.delete(proxyObject)
+    }
+  }
+}
+const isPending = (proxyObject: object) => {
+  const count = pendingCountMap.get(proxyObject) || 0
+  return count > 0
+}
 
 /**
  * derive
@@ -61,10 +82,11 @@ export const derive = <T extends object, U extends object>(
   const notifyInSync = options?.sync
   const subscriptions: Subscriptions<U> = getSubscriptions(proxyObject)
   const addSubscription = (p: object, key: keyof U, callback: () => void) => {
-    const subscription = subscriptions.get(p)
-    if (subscription) {
-      subscription[0].set(key, callback)
-    } else {
+    let subscription = subscriptions.get(p)
+    if (!subscription) {
+      const notify = () =>
+        (subscription as Subscription<U>)[0].forEach((cb) => cb())
+      let promise: Promise<void> | undefined
       const unsubscribe = subscribe(
         p,
         (ops) => {
@@ -77,14 +99,28 @@ export const derive = <T extends object, U extends object>(
             // only setting derived properties
             return
           }
-          subscriptions.get(p)?.[0].forEach((cb) => {
-            cb()
-          })
+          if (promise) {
+            // already scheduled
+            return
+          }
+          const unmark = markPending(p)
+          if (notifyInSync) {
+            unmark()
+            notify()
+          } else {
+            promise = Promise.resolve().then(() => {
+              promise = undefined
+              unmark()
+              notify()
+            })
+          }
         },
-        notifyInSync
+        true
       )
-      subscriptions.set(p, [new Map([[key, callback]]), unsubscribe])
+      subscription = [new Map(), unsubscribe]
+      subscriptions.set(p, subscription)
     }
+    subscription[0].set(key, callback)
   }
   const removeSubscription = (p: object, key: keyof U) => {
     const subscription = subscriptions.get(p)
@@ -105,6 +141,10 @@ export const derive = <T extends object, U extends object>(
     let lastDependencies: Map<object, number> | null = null
     const evaluate = () => {
       if (lastDependencies) {
+        if (Array.from(lastDependencies).some(([p]) => isPending(p))) {
+          // some dependencies are still pending
+          return
+        }
         if (
           Array.from(lastDependencies).every(([p, n]) => getVersion(p) === n)
         ) {

--- a/src/utils/derive.ts
+++ b/src/utils/derive.ts
@@ -118,7 +118,7 @@ export const derive = <T extends object, U extends object>(
         return p
       }
       const value = fn(get)
-      const subscribe = () => {
+      const subscribeToDependencies = () => {
         dependencies.forEach((_, p) => {
           if (!lastDependencies?.has(p)) {
             addSubscription(p, key, evaluate)
@@ -132,9 +132,9 @@ export const derive = <T extends object, U extends object>(
         lastDependencies = dependencies
       }
       if (value instanceof Promise) {
-        value.finally(subscribe)
+        value.finally(subscribeToDependencies)
       } else {
-        subscribe()
+        subscribeToDependencies()
       }
       proxyObject[key] = value
     }

--- a/src/utils/derive.ts
+++ b/src/utils/derive.ts
@@ -26,7 +26,7 @@ const getSubscriptions = (proxyObject: object) => {
 // It's not expected to use this in production.
 export const unstable_getDeriveSubscriptions = getSubscriptions
 
-// to make derive glitch free
+// to make derive glitch free: https://github.com/pmndrs/valtio/pull/335
 const pendingCountMap = new WeakMap<object, number>()
 const markPending = (proxyObject: object) => {
   const count = pendingCountMap.get(proxyObject) || 0

--- a/src/utils/derive.ts
+++ b/src/utils/derive.ts
@@ -31,13 +31,13 @@ const pendingCountMap = new WeakMap<object, number>()
 const markPending = (proxyObject: object) => {
   const count = pendingCountMap.get(proxyObject) || 0
   pendingCountMap.set(proxyObject, count + 1)
-  return () => {
-    const count = pendingCountMap.get(proxyObject) || 0
-    if (count > 1) {
-      pendingCountMap.set(proxyObject, count - 1)
-    } else {
-      pendingCountMap.delete(proxyObject)
-    }
+}
+const unmarkPending = (proxyObject: object) => {
+  const count = pendingCountMap.get(proxyObject) || 0
+  if (count > 1) {
+    pendingCountMap.set(proxyObject, count - 1)
+  } else {
+    pendingCountMap.delete(proxyObject)
   }
 }
 const isPending = (proxyObject: object) => {
@@ -103,14 +103,14 @@ export const derive = <T extends object, U extends object>(
             // already scheduled
             return
           }
-          const unmark = markPending(p)
+          markPending(p)
           if (notifyInSync) {
-            unmark()
+            unmarkPending(p)
             notify()
           } else {
             promise = Promise.resolve().then(() => {
               promise = undefined
-              unmark()
+              unmarkPending(p)
               notify()
             })
           }

--- a/tests/derive.test.tsx
+++ b/tests/derive.test.tsx
@@ -300,7 +300,7 @@ it('basic underive', async () => {
   expect(callback).toBeCalledTimes(1)
 })
 
-describe('glich free', () => {
+describe('glitch free', () => {
   it('basic (#296)', async () => {
     const state = proxy({ value: 0 })
     const derived1 = derive({

--- a/tests/derive.test.tsx
+++ b/tests/derive.test.tsx
@@ -384,4 +384,51 @@ describe('glich free', () => {
     await findByText('value: 1')
     expect(computeValue).toBeCalledTimes(2)
   })
+
+  it('double chain', async () => {
+    const state = proxy({ value: 0 })
+    const derived1 = derive({
+      value: (get) => get(state).value,
+    })
+    const derived2 = derive({
+      value: (get) => get(derived1).value,
+    })
+    const derived3 = derive({
+      value: (get) => get(derived2).value,
+    })
+    const computeValue = jest.fn((get) => {
+      const v0 = get(state).value
+      const v1 = get(derived1).value
+      const v2 = get(derived2).value
+      const v3 = get(derived3).value
+      return v0 + (v1 - v2) + v3 * 0
+    })
+    const derived4 = derive({
+      value: (get) => computeValue(get),
+    })
+
+    const App = () => {
+      const snap = useSnapshot(derived4)
+      return (
+        <div>
+          value: {snap.value}
+          <button onClick={() => ++state.value}>button</button>
+        </div>
+      )
+    }
+
+    const { getByText, findByText } = render(
+      <StrictMode>
+        <App />
+      </StrictMode>
+    )
+
+    await findByText('value: 0')
+    expect(computeValue).toBeCalledTimes(1)
+
+    fireEvent.click(getByText('button'))
+    await findByText('value: 1')
+    expect(computeValue).toBeCalledTimes(2)
+  })
+
 })

--- a/tests/derive.test.tsx
+++ b/tests/derive.test.tsx
@@ -211,7 +211,7 @@ it('nested emulation with derive', async () => {
     {
       doubled: (get) => computeDouble(get(state.math).count),
     },
-    { proxy: state.math }
+    { proxy: state.math, sync: true }
   )
 
   const callback = jest.fn()
@@ -430,5 +430,4 @@ describe('glich free', () => {
     await findByText('value: 1')
     expect(computeValue).toBeCalledTimes(2)
   })
-
 })

--- a/tests/derive.test.tsx
+++ b/tests/derive.test.tsx
@@ -299,3 +299,89 @@ it('basic underive', async () => {
   await Promise.resolve()
   expect(callback).toBeCalledTimes(1)
 })
+
+describe('glich free', () => {
+  it('basic (#296)', async () => {
+    const state = proxy({ value: 0 })
+    const derived1 = derive({
+      value: (get) => get(state).value,
+    })
+    const derived2 = derive({
+      value: (get) => get(derived1).value,
+    })
+    const computeValue = jest.fn((get) => {
+      const v0 = get(state).value
+      const v1 = get(derived1).value
+      const v2 = get(derived2).value
+      return v0 + (v1 - v2)
+    })
+    const derived3 = derive({
+      value: (get) => computeValue(get),
+    })
+
+    const App = () => {
+      const snap = useSnapshot(derived3)
+      return (
+        <div>
+          value: {snap.value}
+          <button onClick={() => ++state.value}>button</button>
+        </div>
+      )
+    }
+
+    const { getByText, findByText } = render(
+      <StrictMode>
+        <App />
+      </StrictMode>
+    )
+
+    await findByText('value: 0')
+    expect(computeValue).toBeCalledTimes(1)
+
+    fireEvent.click(getByText('button'))
+    await findByText('value: 1')
+    expect(computeValue).toBeCalledTimes(2)
+  })
+
+  it('same value', async () => {
+    const state = proxy({ value: 0 })
+    const derived1 = derive({
+      value: (get) => get(state).value * 0,
+    })
+    const derived2 = derive({
+      value: (get) => get(derived1).value * 0,
+    })
+    const computeValue = jest.fn((get) => {
+      const v0 = get(state).value
+      const v1 = get(derived1).value
+      const v2 = get(derived2).value
+      return v0 + (v1 - v2)
+    })
+    const derived3 = derive({
+      value: (get) => computeValue(get),
+    })
+
+    const App = () => {
+      const snap = useSnapshot(derived3)
+      return (
+        <div>
+          value: {snap.value}
+          <button onClick={() => ++state.value}>button</button>
+        </div>
+      )
+    }
+
+    const { getByText, findByText } = render(
+      <StrictMode>
+        <App />
+      </StrictMode>
+    )
+
+    await findByText('value: 0')
+    expect(computeValue).toBeCalledTimes(1)
+
+    fireEvent.click(getByText('button'))
+    await findByText('value: 1')
+    expect(computeValue).toBeCalledTimes(2)
+  })
+})


### PR DESCRIPTION
@mweststrate hinted that a solution to make glitch free is simply to use a counter. https://twitter.com/mweststrate/status/1484928361084379136

So I tried. closes #296 

I had to make the subscription sync and then async in derive. There might be some edge cases this won't work well, like mixing sync and async, but the basic patterns should be covered. Let's see how it goes with releasing this.