### PR TITLE
fix(types): workaround for extracting types

### DIFF
--- a/src/utils/proxyWithComputed.ts
+++ b/src/utils/proxyWithComputed.ts
@@ -1,12 +1,28 @@
 import { createProxy as createProxyToCompare, isChanged } from 'proxy-compare'
 import { proxy, snapshot } from '../vanilla'
 
-class SnapshotWrapper<T extends object> {
-  fn(p: T) {
-    return snapshot(p)
-  }
-}
-type Snapshot<T extends object> = ReturnType<SnapshotWrapper<T>['fn']>
+// Unfortunatly, this doesn't work with tsc.
+// Hope to find a solution to make this work.
+//
+//   class SnapshotWrapper<T extends object> {
+//     fn(p: T) {
+//       return snapshot(p)
+//     }
+//   }
+//   type Snapshot<T extends object> = ReturnType<SnapshotWrapper<T>['fn']>
+//
+// Using copy-paste types for now:
+type AsRef = { $$valtioRef: true }
+type AnyFunction = (...args: any[]) => any
+type Snapshot<T> = T extends AnyFunction
+  ? T
+  : T extends AsRef
+  ? T
+  : T extends Promise<infer V>
+  ? Snapshot<V>
+  : {
+      readonly [K in keyof T]: Snapshot<T[K]>
+    }
 
 /**
  * proxyWithComputed


### PR DESCRIPTION
fix #340.

Somehow, tsc compiles into weird types, if it comes with unexported types.
If we use the `class` hack in typescript playground, it works:
https://tsplay.dev/WG5kJN
So, I guess this is the issue of building, rather than a technical limitation.

Until we find a proper solution for building, let's at least fix this and release it.