### PR TITLE
fix(docs): add note in readme about loose typing of useSnapshot

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,23 @@ function Counter() {
 ```
 
 <details>
+<summary>Note for TypeScript users: Return type of useSnapshot can be too strict.</summary>
+
+The `snap` variable returned by `useSnapshot` is a (deeply) read-only object.
+Its type has `readonly` attribute, which may be too strict for some use cases.
+
+To mitigate typing difficulties, you might want to consider creating a utility function like this:
+```ts
+const useSnapshotLooselyTyped = <T extends object>(
+  proxyObject: T,
+  options: Parameters<typeof useSnapshot>[1],
+) => useSnapshot(proxyObject, options) as T
+```
+
+See [#327](https://github.com/pmndrs/valtio/issues/327) for more information.
+</details>
+
+<details>
 <summary>Note: useSnapshot returns a new proxy for render optimization.</summary>
 
 Internally, `useSnapshot` calls `snapshot` in valtio/vanilla,

--- a/readme.md
+++ b/readme.md
@@ -53,12 +53,11 @@ function Counter() {
 The `snap` variable returned by `useSnapshot` is a (deeply) read-only object.
 Its type has `readonly` attribute, which may be too strict for some use cases.
 
-To mitigate typing difficulties, you might want to consider creating a utility function like this:
+To mitigate typing difficulties, you might want to loosen the type definition:
 ```ts
-const useSnapshotLooselyTyped = <T extends object>(
-  proxyObject: T,
-  options: Parameters<typeof useSnapshot>[1],
-) => useSnapshot(proxyObject, options) as T
+declare module "valtio" {
+  function useSnapshot<T extends object>(p: T): T;
+}
 ```
 
 See [#327](https://github.com/pmndrs/valtio/issues/327) for more information.


### PR DESCRIPTION
close #327 

---
 With #359, we can do [Module Augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).

https://codesandbox.io/s/react-typescript-forked-qphpi?file=/src/App.tsx:46-125
```ts
declare module "valtio" {
  function useSnapshot<T extends object>(p: T): T;
}
```
