### PR TITLE
Fix "Please install/enable Redux devtools" warning in "test" environments like jest

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -66,7 +66,8 @@ function createESMConfig(input, output) {
       }),
       resolve({ extensions }),
       replace({
-        __DEV__: '(import.meta.env&&import.meta.env.MODE)!=="production"',
+        __DEV__:
+          '(import.meta.env&&import.meta.env.MODE)!=="production"&&(import.meta.env&&import.meta.env.MODE)!=="test"',
         preventAssignment: true,
       }),
       getEsbuild('node12'),
@@ -88,7 +89,8 @@ function createCommonJSConfig(input, output) {
       }),
       resolve({ extensions }),
       replace({
-        __DEV__: 'process.env.NODE_ENV!=="production"',
+        __DEV__:
+          'process.env.NODE_ENV!=="production"&&process.env.NODE_ENV!=="test"',
         preventAssignment: true,
       }),
       babelPlugin(getBabelOptions({ ie: 11 })),
@@ -123,7 +125,8 @@ function createUMDConfig(input, output, env) {
       }),
       resolve({ extensions }),
       replace({
-        __DEV__: env !== 'production' ? 'true' : 'false',
+        __DEV__:
+          env !== 'production' ? (env !== 'test' ? 'true' : 'false') : 'false',
         preventAssignment: true,
       }),
       babelPlugin(getBabelOptions({ ie: 11 })),
@@ -150,7 +153,8 @@ function createSystemConfig(input, output, env) {
       }),
       resolve({ extensions }),
       replace({
-        __DEV__: env !== 'production' ? 'true' : 'false',
+        __DEV__:
+          env !== 'production' ? (env !== 'test' ? 'true' : 'false') : 'false',
         preventAssignment: true,
       }),
       getEsbuild('node12', env),


### PR DESCRIPTION
Hi there! 👋 

I found the following issue:
![Screenshot 2022-02-21 at 13 22 57](https://user-images.githubusercontent.com/6549140/154979620-f75553b5-671b-456f-b15f-5ea1b308b564.png)

This is when I run jest. I'm testing a function that does not interact with Valtio state in any way, but it is in a file that has other functions that do interact with valtio state (so state is imported into this file). for example if I tested the `add()` function from the following file I would get the warning:
```
import { AppState } from '../state/AppState'

export const updateState = () => AppState.name = 'hello'

export const add = (x, y) => x + y
```

I've not looked at the repo before and I'm not a TypeScript pro, but I believe the rollup config sets the `__DEV__` global type. I have updated the rollup config and this is the compiled code after fix has been added, which is solves this issue:
```
  if (!extension) {
    if (process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "test" && typeof window !== 'undefined') {
      console.warn('[Warning] Please install/enable Redux devtools extension');
    }

    return;
  }
  ```

All tests currently pass fine, but wonder if `devtools.test.tsx` need updating to reflect this change.
  