### PR TITLE
feat(website): prism theme for syntax highlights

### DIFF
--- a/docs/advanced/snapshot.mdx
+++ b/docs/advanced/snapshot.mdx
@@ -10,7 +10,7 @@ description: 'Create a snapshot of current state'
   
 Immutability is achieved by deeply freezing the object. In sequential snapshot calls, when the values in the proxy have not changed, a pointer to the same object is returned. This allows for shallow comparison in render functions, preventing spurious renders. Snapshots also throw promises, making them work with React Suspense.
 
-```jsx
+```js
 import { proxy, snapshot } from 'valtio'
 
 const store = proxy({ name: "Mika" });

--- a/docs/advanced/subscribe.mdx
+++ b/docs/advanced/subscribe.mdx
@@ -28,7 +28,6 @@ const state = proxy({ obj: { foo: 'bar' }, arr: ['hello'] })
 
 subscribe(state.obj, () => console.log('state.obj has changed to', state.obj))
 state.obj.foo = 'baz'
-
 subscribe(state.arr, () => console.log('state.arr has changed to', state.arr))
 state.arr.push('world')
 ```

--- a/docs/basic/proxy.mdx
+++ b/docs/basic/proxy.mdx
@@ -8,7 +8,7 @@ description: 'Create a proxy object.'
 
 The proxy tracks changes to the original object and all nested objects, notifying listeners when an object is modified.
 
-```jsx
+```js
 import { proxy, useSnapshot } from 'valtio'
 
 const state = proxy({ count: 0, text: 'hello' })
@@ -18,7 +18,7 @@ const state = proxy({ count: 0, text: 'hello' })
 
 You can make changes to it in the same way you would to a normal js-object.
 
-```jsx
+```js
 setInterval(() => {
   ++state.count
 }, 1000)
@@ -30,7 +30,7 @@ Noop
 
 Updates that set the value of a property to the same value are ignored. Subscribers will not be informed of a version change.
 
-```jsx
+```js
 const state = proxy({ count: 0 })
 
 state.count = 0 // has no effect
@@ -40,7 +40,7 @@ Batching
 
 Multiple changes in the same event loop tick to will be batched together. Subscribers will be notified of a single version change.
 
-```jsx
+```js
 const state = proxy({ count: 0, text: 'hello' })
 // subscribers will be notified once after both mutations
 state.count = 1

--- a/docs/basic/proxy.mdx
+++ b/docs/basic/proxy.mdx
@@ -83,7 +83,8 @@ state.user.name = "Nina"
 Not everything can be proxied. Generally, you are safe if it is serializable. Classes can also be proxied. But avoid special objects. 
 
 ```jsx
-  // these won't work - changes to these objects causes updates
+  // these won't work - changes to these objects won't cause updates
+  // to store state that is unproxied see the docs on ref
   const state = proxy({
     chart: d3.select('#chart'),
     component: React.createElement('div'),

--- a/docs/basic/useSnapshot.mdx
+++ b/docs/basic/useSnapshot.mdx
@@ -6,16 +6,12 @@ description: 'Create a local snapshot taht catches changes.'
 
 # useSnapshot
 
-useSnapshot
-
 Create a local snapshot that catches changes. This hook actually returns a wrapped snapshot in a proxy for
 render optimization instead of a plain object compared to <a href="/docs/advanced/snapshot">`snapshot()`</a> method.
 Rule of thumb: read from snapshots, mutate the source.
 The component will only re-render when the parts of the state you access have changed, it is render-optimized.
 
-@example A
-
-```
+```jsx
 function Counter() {
 	const snap = useSnapshot(state)
 	return (
@@ -31,9 +27,7 @@ function Counter() {
 Every object inside your proxy also becomes a proxy (if you don't use "ref"), so you can also use them to create
 the local snapshot as seen on example B.
 
-@example B
-
-```
+```jsx
 function ProfileName() {
 	const snap = useSnapshot(state.profile)
 	return (
@@ -45,7 +39,7 @@ function ProfileName() {
 Beware that you still can replace the child proxy with something else so it will break your snapshot. You can see
 above what happens with the original proxy when you replace the child proxy.
 
-```
+```js
 > console.log(state)
 > { profile: { name: "valtio" } }
 > childState = state.profile
@@ -67,18 +61,15 @@ that is subscribed to the old proxy won't receive new updates because it is stil
 In this case we recommend the example C or D. On both examples you don't need to worry with re-render,
 because it is render-optimized.
 
-@example C
-
-```
+```jsx
 const snap = useSnapshot(state)
+
 return (
 	<div>{snap.profile.name}</div>
 )
 ```
 
-@example D
-
-```
+```jsx
 const { profile } = useSnapshot(state)
 
 return (

--- a/docs/basic/useSnapshot.mdx
+++ b/docs/basic/useSnapshot.mdx
@@ -40,19 +40,19 @@ Beware that you still can replace the child proxy with something else so it will
 above what happens with the original proxy when you replace the child proxy.
 
 ```js
-> console.log(state)
-> { profile: { name: "valtio" } }
-> childState = state.profile
-> console.log(childState)
-> { name: "valtio" }
-> state.profile.name = "react"
-> console.log(childState)
-> { name: "react" }
-> state.profile = { name: "new name" }
-> console.log(childState)
-> { name: "react" }
-> console.log(state)
-> { profile: { name: "new name" } }
+console.log(state)
+{ profile: { name: "valtio" } }
+childState = state.profile
+console.log(childState)
+{ name: "valtio" }
+state.profile.name = "react"
+console.log(childState)
+{ name: "react" }
+state.profile = { name: "new name" }
+console.log(childState)
+{ name: "react" }
+console.log(state)
+{ profile: { name: "new name" } }
 ```
 
 `useSnapshot()` depends on the original reference of the child proxy so if you replace it with a new one, the component

--- a/website/pages/_app.tsx
+++ b/website/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { NextPage } from "next";
 import type { AppProps } from "next/app";
 
 import "~/styles/tailwind.css";
+import "~/styles/prism-theme.css";
 
 type NextPageWithLayout = NextPage & {
   layoutProps: {

--- a/website/styles/prism-theme.css
+++ b/website/styles/prism-theme.css
@@ -1,139 +1,124 @@
-/*
- * This was adapted from the Synthwave '84 Theme originally by Robb Owen
- * and ported for PrismJS by Marc Backes. We made it bluer and more Valtio-ish.
- * 
+ /*
+ * Nord Theme Originally by Arctic Ice Studio
+ * https://nordtheme.com
+ *
+ * Ported for PrismJS by Zane Hitchcoxc (@zwhitchcox) and Gabriel Ramos (@gabrieluizramos)
  */
 
- code[class*="language-"],
- pre[class*="language-"] {
-   color:  #22d3ee;
-   text-shadow: 0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3;
-   background: none;
-   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-   font-size: 1em;
-   text-align: left;
-   white-space: pre;
-   word-spacing: normal;
-   word-break: normal;
-   word-wrap: normal;
-   line-height: 1.5;
- 
-   -moz-tab-size: 4;
-   -o-tab-size: 4;
-   tab-size: 4;
- 
-   -webkit-hyphens: none;
-   -moz-hyphens: none;
-   -ms-hyphens: none;
-   hyphens: none;
- }
- 
- /* Code blocks */
- pre[class*="language-"] {
-   padding: 1em;
-   margin: .5em 0;
-   overflow: auto;
- }
- 
- :not(pre) > code[class*="language-"],
- pre[class*="language-"] {
-   background-color: transparent !important;
-   background-image: linear-gradient(to bottom, #2a2139 75%, #34294f);
- }
- 
- /* Inline code */
- :not(pre) > code[class*="language-"] {
-   padding: .1em;
-   border-radius: .3em;
-   white-space: normal;
- }
- 
- .token.comment,
- .token.block-comment,
- .token.prolog,
- .token.doctype,
- .token.cdata {
-   color: #8e8e8e;
- }
- 
- .token.punctuation {
-   color: #ccc;
- }
- 
- .token.tag,
- .token.attr-name,
- .token.namespace,
- .token.number,
- .token.unit,
- .token.hexcode,
- .token.deleted {
-   color: #0891b2;
- }
- 
- .token.property,
- .token.selector {
-   color: #72f1b8;;
-   text-shadow: 0 0 2px #100c0f, 0 0 10px #257c5575, 0 0 35px #21272475;
- }
- 
- .token.function-name {
-   color: #22d3ee;
- }
- 
- .token.boolean,
- .token.selector .token.id,
- .token.function {
-   color: #fdfdfd;
-   text-shadow: 0 0 2px #001716, 0 0 3px #03edf975, 0 0 5px #03edf975, 0 0 8px #03edf975;
- }
- 
- .token.class-name {
-   color: #fff5f6;
-   text-shadow: 0 0 2px #000, 0 0 10px #cafe48, 0 0 5px #cafe48, 0 0 25px #cafe48;
- }
- 
- .token.constant,
- .token.symbol {
-   color: #d946ef;
-   text-shadow: 0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3;
- }
- 
- .token.important,
- .token.atrule,
- .token.keyword,
- .token.selector .token.class,
- .token.builtin {
-   color: #f4eee4;
-   text-shadow: 0 0 2px #393a33, 0 0 8px #f39f0575, 0 0 2px #f39f0575;
- }
- 
- .token.string,
- .token.char,
- .token.attr-value,
- .token.regex,
- .token.variable {
-   color: #0891b2;
- }
- 
- .token.operator,
- .token.entity,
- .token.url {
-   color: rgb(14 165 233 / 0.9);
- }
- 
- .token.important,
- .token.bold {
-   font-weight: bold;
- }
- 
- .token.italic {
-   font-style: italic;
- }
- 
- .token.entity {
-   cursor: help;
- }
- 
- .token.inserted {
-   color: green;
- }
+code[class*="language-"],
+pre[class*="language-"] {
+	color: #f8f8f2;
+	background: none;
+	font-family: "Fira Code", Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+	border-radius: 0.3em;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #2E3440;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: #636f88;
+}
+
+.token.punctuation {
+	color: #81A1C1;
+}
+
+.namespace {
+	opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+	color: #81A1C1;
+}
+
+.token.number {
+	color: #B48EAD;
+}
+
+.token.boolean {
+	color: #81A1C1;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+	color: #A3BE8C;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+	color: #81A1C1;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.function,
+.token.class-name {
+	color: #88C0D0;
+}
+
+.token.keyword {
+	color: #81A1C1;
+}
+
+.token.regex,
+.token.important {
+	color: #EBCB8B;
+}
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}

--- a/website/styles/prism-theme.css
+++ b/website/styles/prism-theme.css
@@ -1,0 +1,139 @@
+/*
+ * This was adapted from the Synthwave '84 Theme originally by Robb Owen
+ * and ported for PrismJS by Marc Backes. We made it bluer and more Valtio-ish.
+ * 
+ */
+
+ code[class*="language-"],
+ pre[class*="language-"] {
+   color:  #22d3ee;
+   text-shadow: 0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3;
+   background: none;
+   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+   font-size: 1em;
+   text-align: left;
+   white-space: pre;
+   word-spacing: normal;
+   word-break: normal;
+   word-wrap: normal;
+   line-height: 1.5;
+ 
+   -moz-tab-size: 4;
+   -o-tab-size: 4;
+   tab-size: 4;
+ 
+   -webkit-hyphens: none;
+   -moz-hyphens: none;
+   -ms-hyphens: none;
+   hyphens: none;
+ }
+ 
+ /* Code blocks */
+ pre[class*="language-"] {
+   padding: 1em;
+   margin: .5em 0;
+   overflow: auto;
+ }
+ 
+ :not(pre) > code[class*="language-"],
+ pre[class*="language-"] {
+   background-color: transparent !important;
+   background-image: linear-gradient(to bottom, #2a2139 75%, #34294f);
+ }
+ 
+ /* Inline code */
+ :not(pre) > code[class*="language-"] {
+   padding: .1em;
+   border-radius: .3em;
+   white-space: normal;
+ }
+ 
+ .token.comment,
+ .token.block-comment,
+ .token.prolog,
+ .token.doctype,
+ .token.cdata {
+   color: #8e8e8e;
+ }
+ 
+ .token.punctuation {
+   color: #ccc;
+ }
+ 
+ .token.tag,
+ .token.attr-name,
+ .token.namespace,
+ .token.number,
+ .token.unit,
+ .token.hexcode,
+ .token.deleted {
+   color: #0891b2;
+ }
+ 
+ .token.property,
+ .token.selector {
+   color: #72f1b8;;
+   text-shadow: 0 0 2px #100c0f, 0 0 10px #257c5575, 0 0 35px #21272475;
+ }
+ 
+ .token.function-name {
+   color: #22d3ee;
+ }
+ 
+ .token.boolean,
+ .token.selector .token.id,
+ .token.function {
+   color: #fdfdfd;
+   text-shadow: 0 0 2px #001716, 0 0 3px #03edf975, 0 0 5px #03edf975, 0 0 8px #03edf975;
+ }
+ 
+ .token.class-name {
+   color: #fff5f6;
+   text-shadow: 0 0 2px #000, 0 0 10px #cafe48, 0 0 5px #cafe48, 0 0 25px #cafe48;
+ }
+ 
+ .token.constant,
+ .token.symbol {
+   color: #d946ef;
+   text-shadow: 0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3;
+ }
+ 
+ .token.important,
+ .token.atrule,
+ .token.keyword,
+ .token.selector .token.class,
+ .token.builtin {
+   color: #f4eee4;
+   text-shadow: 0 0 2px #393a33, 0 0 8px #f39f0575, 0 0 2px #f39f0575;
+ }
+ 
+ .token.string,
+ .token.char,
+ .token.attr-value,
+ .token.regex,
+ .token.variable {
+   color: #0891b2;
+ }
+ 
+ .token.operator,
+ .token.entity,
+ .token.url {
+   color: rgb(14 165 233 / 0.9);
+ }
+ 
+ .token.important,
+ .token.bold {
+   font-weight: bold;
+ }
+ 
+ .token.italic {
+   font-style: italic;
+ }
+ 
+ .token.entity {
+   cursor: help;
+ }
+ 
+ .token.inserted {
+   color: green;
+ }


### PR DESCRIPTION
![Screenshot 2022-02-24 at 22 11 43](https://user-images.githubusercontent.com/7317771/155600042-7d07255b-755a-4346-8870-6d1e6dc6bdbc.png)

This is an adaptation of https://github.com/PrismJS/prism-themes/blob/master/themes/prism-synthwave84.css but made bluer and a bit less wild. Still a bit neon. Probably could user further tweaking.