### PR TITLE
[website] fix getting started style

### DIFF
--- a/docs/introduction/getting-started.mdx
+++ b/docs/introduction/getting-started.mdx
@@ -15,7 +15,6 @@ import logo from './logo.svg'
 
 ```bash
 npm i valtio
-
 ```
 
 #### Recipes


### PR DESCRIPTION
Current getting started page on website contains an extra line.
![image](https://user-images.githubusercontent.com/32315294/157391301-989a6241-daea-456d-910e-33a76200dc19.png)
