### PR TITLE
fix(utils): devtools better types

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "prettier": "^2.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "redux": "^4.1.2",
     "rollup": "^2.68.0",
     "rollup-plugin-esbuild": "^4.8.2",
     "rollup-plugin-terser": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "@babel/plugin-transform-typescript": "^7.16.8",
     "@babel/preset-env": "^7.16.11",
     "@babel/types": "^7.17.0",
+    "@redux-devtools/extension": "^3.2.2",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-node-resolve": "^13.1.3",

--- a/src/utils/devtools.ts
+++ b/src/utils/devtools.ts
@@ -36,8 +36,7 @@ export function devtools<T extends object>(proxyObject: T, name = '') {
   }
 
   let isTimeTraveling = false
-  const devtools: ReturnType<NonNullable<typeof extension>['connect']> =
-    extension.connect({ name })
+  const devtools = extension.connect({ name })
   const unsub1 = subscribe(proxyObject, (ops) => {
     const action = ops
       .filter(([_, path]) => path[0] !== DEVTOOLS)

--- a/src/utils/devtools.ts
+++ b/src/utils/devtools.ts
@@ -1,6 +1,12 @@
 import { snapshot, subscribe } from '../vanilla'
+import type {} from '@redux-devtools/extension'
 
-type Message = { type: string; payload?: any; state?: any }
+// FIXME https://github.com/reduxjs/redux-devtools/issues/1097
+export type Message = {
+  type: string
+  payload?: any
+  state?: any
+}
 
 const DEVTOOLS = Symbol()
 
@@ -15,10 +21,10 @@ const DEVTOOLS = Symbol()
  * const state = proxy({ count: 0, text: 'hello' })
  * const unsub = devtools(state, 'state name')
  */
-export function devtools<T extends object>(proxyObject: T, name?: string) {
-  let extension: any
+export function devtools<T extends object>(proxyObject: T, name: string = '') {
+  let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__']
   try {
-    extension = (window as any).__REDUX_DEVTOOLS_EXTENSION__
+    extension = window.__REDUX_DEVTOOLS_EXTENSION__
   } catch {
     // ignored
   }
@@ -30,7 +36,8 @@ export function devtools<T extends object>(proxyObject: T, name?: string) {
   }
 
   let isTimeTraveling = false
-  const devtools = extension.connect({ name })
+  const devtools: ReturnType<NonNullable<typeof extension>['connect']> =
+    extension.connect({ name })
   const unsub1 = subscribe(proxyObject, (ops) => {
     const action = ops
       .filter(([_, path]) => path[0] !== DEVTOOLS)
@@ -50,12 +57,19 @@ export function devtools<T extends object>(proxyObject: T, name?: string) {
         {
           type: action,
           updatedAt: new Date().toLocaleString(),
-        },
+        } as any,
         snapWithoutDevtools
       )
     }
   })
-  const unsub2 = devtools.subscribe((message: Message) => {
+  const unsub2 = (
+    devtools as unknown as {
+      // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
+      subscribe: (
+        listener: (message: Message) => void
+      ) => (() => void) | undefined
+    }
+  ).subscribe((message: Message) => {
     if (message.type === 'ACTION' && message.payload) {
       try {
         Object.assign(proxyObject, JSON.parse(message.payload))
@@ -108,6 +122,6 @@ export function devtools<T extends object>(proxyObject: T, name?: string) {
   devtools.init(snapshot(proxyObject))
   return () => {
     unsub1()
-    unsub2()
+    unsub2?.()
   }
 }

--- a/src/utils/devtools.ts
+++ b/src/utils/devtools.ts
@@ -68,7 +68,7 @@ export function devtools<T extends object>(proxyObject: T, name = '') {
         listener: (message: Message) => void
       ) => (() => void) | undefined
     }
-  ).subscribe((message: Message) => {
+  ).subscribe((message) => {
     if (message.type === 'ACTION' && message.payload) {
       try {
         Object.assign(proxyObject, JSON.parse(message.payload))

--- a/src/utils/devtools.ts
+++ b/src/utils/devtools.ts
@@ -21,7 +21,7 @@ const DEVTOOLS = Symbol()
  * const state = proxy({ count: 0, text: 'hello' })
  * const unsub = devtools(state, 'state name')
  */
-export function devtools<T extends object>(proxyObject: T, name: string = '') {
+export function devtools<T extends object>(proxyObject: T, name = '') {
   let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__']
   try {
     extension = window.__REDUX_DEVTOOLS_EXTENSION__

--- a/src/utils/devtools.ts
+++ b/src/utils/devtools.ts
@@ -2,7 +2,7 @@ import { snapshot, subscribe } from '../vanilla'
 import type {} from '@redux-devtools/extension'
 
 // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
-export type Message = {
+type Message = {
   type: string
   payload?: any
   state?: any

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,7 +903,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.17.0", "@babel/runtime@^7.8.4":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -1207,6 +1207,13 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@redux-devtools/extension@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@redux-devtools/extension/-/extension-3.2.2.tgz#2d6da4df2c4d32a0aac54d824e46f52b1fd9fc4d"
+  integrity sha512-fKA2TWNzJF7wXSDwBemwcagBFudaejXCzH5hRszN3Z6B7XEJtEmGD77AjV0wliZpIZjA/fs3U7CejFMQ+ipS7A==
+  dependencies:
+    "@babel/runtime" "^7.17.0"
 
 "@rollup/plugin-alias@^3.1.9":
   version "3.1.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,7 +903,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.17.0", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.17.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -4442,6 +4442,13 @@ rechoir@^0.6.2:
   integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
   dependencies:
     resolve "^1.1.6"
+
+redux@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
+  integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 regenerate-unicode-properties@^10.0.1:
   version "10.0.1"


### PR DESCRIPTION
> This PR tries to bring the native `window.__REDUX_DEVTOOLS_EXTENSION__` types from redux devtools and then avoids some custom types which may be incorrect in some cases!


Related: https://github.com/pmndrs/zustand/pull/819, https://github.com/pmndrs/jotai/pull/1049