### PR TITLE
[docs] Improve codesandbox style

### DIFF
--- a/docs/advanced/subscribe.mdx
+++ b/docs/advanced/subscribe.mdx
@@ -34,4 +34,4 @@ state.arr.push('world')
 
 ## Codesandbox demo in VanillaJS
 
-https://codesandbox.io/s/valtio-photo-booth-demo-forked-xp8hs?file=/src/main.js
+https://codesandbox.io/s/valtio-photo-booth-demo-forked-xp8hs?file=/src/main.js&codemirror=1&fontsize=14&hidenavigation=1&theme=light&hidedevtools=1

--- a/docs/basic/useSnapshot.mdx
+++ b/docs/basic/useSnapshot.mdx
@@ -79,4 +79,4 @@ return (
 
 ## Codesandbox demo
 
-https://codesandbox.io/s/ping-pong-with-valtio-wb25s?file=/src/App.js
+https://codesandbox.io/s/ping-pong-with-valtio-wb25s?file=/src/App.js&codemirror=1&fontsize=14&hidenavigation=1&theme=light&hidedevtools=1

--- a/docs/utils/proxyMap.mdx
+++ b/docs/utils/proxyMap.mdx
@@ -52,4 +52,4 @@ state.get(key) //undefined
 
 ## Codesandbox demo
 
-https://codesandbox.io/s/github/pmndrs/valtio/tree/main/examples/todo-with-proxyMap
+https://codesandbox.io/s/github/pmndrs/valtio/tree/main/examples/todo-with-proxyMap?codemirror=1&fontsize=14&hidenavigation=0&theme=light&hidedevtools=1

--- a/docs/utils/proxyWithHistory.mdx
+++ b/docs/utils/proxyWithHistory.mdx
@@ -25,4 +25,4 @@ console.log(state.value) // ---> { count: 1 }
 
 ## Codesandbox demo
 
-https://codesandbox.io/s/admiring-wright-2oh2x?file=/src/App.tsx
+https://codesandbox.io/s/admiring-wright-2oh2x?file=/src/App.tsx&codemirror=1&fontsize=14&hidenavigation=1&theme=light&hidedevtools=1

--- a/website/components/layouts/DocLayout/DocLayout.tsx
+++ b/website/components/layouts/DocLayout/DocLayout.tsx
@@ -260,7 +260,7 @@ export default function DocLayout({
             <div className="hidden lg:block fixed z-20 inset-0 top-[3.8125rem] left-[max(0px,calc(50%-45rem))] right-auto w-[19.5rem] pb-10 px-8 overflow-y-auto">
               <Nav nav={nav} fallbackHref={fallbackHref}></Nav>
             </div>
-            <div className="lg:pl-[19.5rem]">
+            <div className="lg:pl-[19.5rem] p-6 mt-6">
               <main className="prose max-w-3xl mx-auto relative z-20 pt-10 xl:max-w-none">
                 {children}
               </main>

--- a/website/lib/mdx.ts
+++ b/website/lib/mdx.ts
@@ -36,15 +36,15 @@ function handleEmbedderHtml(html: GottenHTML, info: TransformerInfo) {
     return makeEmbed(html, "youtube");
   }
   if (url.hostname.includes("codesandbox.io")) {
-    return makeEmbed(html, "codesandbox", "80%");
+    return makeEmbed(html, "codesandbox", "10%");
   }
   return html;
 }
 
-function makeEmbed(html: string, type: string, heightRatio = "56.25%") {
+function makeEmbed(html: string, type: string, heightRatio = "10%") {
   return `
   <div class="embed" data-embed-type="${type}">
-    <div style="padding-bottom: ${heightRatio}">
+    <div class="mb-8 overflow-hidden shadow-lg !dark:shadow-none rounded-md sm:rounded-lg border-b border-gray-200 dark:border-gray-800" style="margin-bottom: ${heightRatio}">
       ${html}
     </div>
   </div>


### PR DESCRIPTION
The current `codesandbox` iframe can be improved by font sizing, top & bottom padding, and more.
Here is the before & after

before:
![image](https://user-images.githubusercontent.com/32315294/159696228-cecde04b-5c04-42a6-a406-3cddeda03023.png)

after:
![image](https://user-images.githubusercontent.com/32315294/159696240-4550c0e1-e14f-4873-a422-454d4f4f81aa.png)
