### PR TITLE
fix(utils/devtools): enabled option and supress warning

### DIFF
--- a/src/utils/devtools.ts
+++ b/src/utils/devtools.ts
@@ -10,6 +10,24 @@ type Message = {
 
 const DEVTOOLS = Symbol()
 
+type Options = {
+  enabled?: boolean
+  name?: string
+}
+
+export function devtools<T extends object>(
+  proxyObject: T,
+  options?: Options
+): (() => void) | undefined
+
+/**
+ * @deprecated Please use { name } option
+ */
+export function devtools<T extends object>(
+  proxyObject: T,
+  name?: string
+): (() => void) | undefined
+
 /**
  * devtools
  *
@@ -21,15 +39,26 @@ const DEVTOOLS = Symbol()
  * const state = proxy({ count: 0, text: 'hello' })
  * const unsub = devtools(state, 'state name')
  */
-export function devtools<T extends object>(proxyObject: T, name = '') {
-  let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__']
+export function devtools<T extends object>(
+  proxyObject: T,
+  options?: Options | string
+) {
+  if (typeof options === 'string') {
+    console.warn('[Deprecated] Please use option object instead of name string')
+    options = { name: options }
+  }
+  const { enabled, name = '' } = options || {}
+
+  let extension: typeof window['__REDUX_DEVTOOLS_EXTENSION__'] | false
   try {
-    extension = window.__REDUX_DEVTOOLS_EXTENSION__
+    extension =
+      (typeof enabled === 'boolean' ? enabled : __DEV__) &&
+      window.__REDUX_DEVTOOLS_EXTENSION__
   } catch {
     // ignored
   }
   if (!extension) {
-    if (__DEV__ && typeof window !== 'undefined') {
+    if (__DEV__ && enabled) {
       console.warn('[Warning] Please install/enable Redux devtools extension')
     }
     return

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -97,7 +97,24 @@ describe('If there is no extension installed...', () => {
     }).not.toThrow()
   })
 
-  it('warns if enabled is true', () => {
+  it('does not warn if enabled is undefined', () => {
+    const obj = proxy({ count: 0 })
+    devtools(obj)
+    const Counter = () => {
+      const snap = useSnapshot(obj)
+      return (
+        <>
+          <div>count: {snap.count}</div>
+          <button onClick={() => ++obj.count}>button</button>
+        </>
+      )
+    }
+    render(<Counter />)
+    expect(consoleWarn).not.toBeCalled()
+  })
+
+  it('[DEV-ONLY] warns if enabled is true', () => {
+    __DEV__ = true
     const obj = proxy({ count: 0 })
     devtools(obj, { enabled: true })
     const Counter = () => {
@@ -113,22 +130,6 @@ describe('If there is no extension installed...', () => {
     expect(consoleWarn).toHaveBeenLastCalledWith(
       '[Warning] Please install/enable Redux devtools extension'
     )
-  })
-
-  it('does not warn if enabled is undefined', () => {
-    const obj = proxy({ count: 0 })
-    devtools(obj)
-    const Counter = () => {
-      const snap = useSnapshot(obj)
-      return (
-        <>
-          <div>count: {snap.count}</div>
-          <button onClick={() => ++obj.count}>button</button>
-        </>
-      )
-    }
-    render(<Counter />)
-    expect(consoleWarn).not.toBeCalled()
   })
 
   it('[PRD-ONLY] does not warn even if enabled is true', () => {

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -99,7 +99,7 @@ describe('If there is no extension installed...', () => {
     __DEV__ = true
     const originalConsoleWarn = console.warn
     console.warn = jest.fn()
-    devtools(obj)
+    devtools(obj, { enabled: true })
 
     render(<Counter />)
     expect(console.warn).toHaveBeenLastCalledWith(

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -46,7 +46,7 @@ beforeEach(() => {
 
 it('connects to the extension by initialiing', () => {
   const obj = proxy({ count: 0 })
-  devtools(obj)
+  devtools(obj, { enabled: true })
 
   const Counter = () => {
     const snap = useSnapshot(obj)
@@ -122,7 +122,7 @@ describe('If there is no extension installed...', () => {
 
 it('updating state should call devtools.send', async () => {
   const obj = proxy({ count: 0 })
-  devtools(obj)
+  devtools(obj, { enabled: true })
 
   const Counter = () => {
     const snap = useSnapshot(obj)
@@ -149,7 +149,7 @@ it('updating state should call devtools.send', async () => {
 describe('when it receives an message of type...', () => {
   it('updating state with ACTION', async () => {
     const obj = proxy({ count: 0 })
-    devtools(obj)
+    devtools(obj, { enabled: true })
 
     const Counter = () => {
       const snap = useSnapshot(obj)
@@ -185,7 +185,7 @@ describe('when it receives an message of type...', () => {
   describe('DISPATCH and payload of type...', () => {
     it('dispatch & COMMIT', async () => {
       const obj = proxy({ count: 0 })
-      devtools(obj)
+      devtools(obj, { enabled: true })
 
       const Counter = () => {
         const snap = useSnapshot(obj)
@@ -218,7 +218,7 @@ describe('when it receives an message of type...', () => {
 
     it('dispatch & IMPORT_STATE', async () => {
       const obj = proxy({ count: 0 })
-      devtools(obj)
+      devtools(obj, { enabled: true })
 
       const Counter = () => {
         const snap = useSnapshot(obj)
@@ -257,7 +257,7 @@ describe('when it receives an message of type...', () => {
     describe('JUMP_TO_STATE | JUMP_TO_ACTION...', () => {
       it('time travelling', async () => {
         const obj = proxy({ count: 0 })
-        devtools(obj)
+        devtools(obj, { enabled: true })
 
         const Counter = () => {
           const snap = useSnapshot(obj)


### PR DESCRIPTION
This adds `enabled` option.
It shows the missing devtools ext warning only if `enabled=true`.
It deprecates bare string `name` option (use `{ name }` instead).

Following the change in https://github.com/pmndrs/zustand/pull/880.