### PR TITLE
Update subscribing example in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ function Foo() {
   const total = useRef(0)
   useEffect(() => subscribe(state.arr, () => {
     total.current = state.arr.reduce((p, c) => p + c)
-  }), [state.obj])
+  }), [state.arr])
   // ...
 ```
 
@@ -231,6 +231,7 @@ const unsub = devtools(state, 'state name')
   <summary>Manipulating state with Redux DevTools</summary>
 The screenshot below shows how to use Redux DevTools to manipulate state. First select the object from the instances drop down. Then type in a JSON object to dispatch. Then click "Dispatch". Notice how it changes the state.
 
+<br/>
 <img width="564" alt="image" src="https://user-images.githubusercontent.com/6372489/141134955-26e9ffce-1e2a-4c8c-a9b3-d9da739610fe.png">
 </details>
 

--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ function Foo() {
   const total = useRef(0)
   useEffect(() => subscribe(state.arr, () => {
     total.current = state.arr.reduce((p, c) => p + c)
-  }), [state.arr])
+  }), [])
   // ...
 ```
 


### PR DESCRIPTION
I think the dependency of the `useEffect` was supposed to be `state.arr`, however, does it make a difference to have it listed in the dependencies if subscribing to it means watching for its changes anyway? 🤔 

Also added a space with `br` in the `details` section about using devtools, to avoid the image getting in the same block of the text.