### PR TITLE
fix(docs): last intro sentence correction

### DIFF
--- a/docs/introduction/getting-started.mdx
+++ b/docs/introduction/getting-started.mdx
@@ -11,7 +11,7 @@ import logo from './logo.svg'
 
 ### Proxy state made simple.
 
-The Valtio api is minimal, flexible, unopinionated and a touch magical. Valtio's proxy turns the object you pass it into a self-aware proxy, allowing fine-grained subscription and creativity in making state updates. In React, Valtio shines at render optimization. It is compatible with Suspense and React 18. Valtio also provides a vanilla javascript, making it a viable option in vanilla applications or with other frameworks.
+The Valtio api is minimal, flexible, unopinionated and a touch magical. Valtio's proxy turns the object you pass it into a self-aware proxy, allowing fine-grained subscription and creativity in making state updates. In React, Valtio shines at render optimization. It is compatible with Suspense and React 18. Valtio is also a viable option in vanilla javascript applications.
 
 #### Installation
 


### PR DESCRIPTION
There seems to have been a missing word in the last sentence of the intro. I shortened to something understandable.