### PR TITLE
breaking(utils): make proxyWithComputed to work with optional proxy-memoize

### DIFF
--- a/docs/utils/proxyWithComputed.mdx
+++ b/docs/utils/proxyWithComputed.mdx
@@ -8,49 +8,43 @@ description: ''
 
 #### add a computation to a proxy
 
-You can have computed values with dependency tracking with property access.
-Dependency tracking in `proxyWithComputed` conflicts with the work in `useSnapshot`.
-React users should prefer using `derive`.
-`proxyWithComputed` works well for some edge cases and for vanilla-js users.
+You can define own computed properties within a proxy.
+By combining with a memoization library such as
+[proxy-memoize](https://github.com/dai-shi/proxy-memoize),
+optimizing function calls is possible.
+
+Be careful not to overuse `proxy-memoize`
+because `proxy-memoize` and `useSnapshot` do similar optimization
+and double optimization may lead to less performance.
 
 ```js
+import memoize from 'proxy-memoize'
 import { proxyWithComputed } from 'valtio/utils'
 
-const state = proxyWithComputed(
-  {
-    count: 1,
-  },
-  {
-    doubled: (snap) => snap.count * 2,
-  }
-)
+const state = proxyWithComputed({
+  count: 1,
+}, {
+  doubled: memoize((snap) => snap.count * 2)
+})
 
 // Computed values accept custom setters too:
-const state2 = proxyWithComputed(
-  {
-    firstName: 'Alec',
-    lastName: 'Baldwin',
-  },
-  {
-    fullName: {
-      get: (snap) => snap.firstName + ' ' + snap.lastName,
-      set: (state, newValue) => {
-        ;[state.firstName, state.lastName] = newValue.split(' ')
-      },
-    },
+const state2 = proxyWithComputed({
+  firstName: 'Alec',
+  lastName: 'Baldwin'
+}, {
+  fullName: {
+    get: memoize((snap) => snap.firstName + ' ' + snap.lastName),
+    set: (state, newValue) => { [state.firstName, state.lastName] = newValue.split(' ') },
   }
-)
+})
 
 // if you want a computed value to derive from another computed, you must declare the dependency first:
-const state = proxyWithComputed(
-  {
-    count: 1,
-  },
-  {
-    doubled: (snap) => snap.count * 2,
-    quadrupled: (snap) => snap.doubled * 2,
-  }
-)
+const state = proxyWithComputed({
+  count: 1,
+}, {
+  doubled: memoize((snap) => snap.count * 2),
+  quadrupled: memoize((snap) => snap.doubled * 2)
+})
 ```
 
 The last use case fails to infer types in TypeScript

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.6.2",
-    "proxy-memoize": "1.0.0",
+    "proxy-memoize": "^1.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "redux": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -209,7 +209,6 @@
     "@babel/types": ">=7.13",
     "aslemammad-vite-plugin-macro": ">=1.0.0-alpha.1",
     "babel-plugin-macros": ">=3.0",
-    "proxy-memoize": ">=1.0.0",
     "react": ">=16.8",
     "vite": ">=2.8.6"
   },
@@ -227,9 +226,6 @@
       "optional": true
     },
     "babel-plugin-macros": {
-      "optional": true
-    },
-    "proxy-memoize": {
       "optional": true
     },
     "react": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
     },
     "moduleNameMapper": {
       "^valtio$": "<rootDir>/src/index.ts",
-      "^valtio/(.*)$": "<rootDir>/src/$1.ts"
+      "^valtio/(.*)$": "<rootDir>/src/$1.ts",
+      "^proxy-memoize$": "<rootDir>/node_modules/proxy-memoize/dist/wrapper.cjs"
     },
     "modulePathIgnorePatterns": [
       "dist"

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.6.2",
+    "proxy-memoize": "1.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "redux": "^4.1.2",
@@ -207,6 +208,7 @@
     "@babel/types": ">=7.13",
     "aslemammad-vite-plugin-macro": ">=1.0.0-alpha.1",
     "babel-plugin-macros": ">=3.0",
+    "proxy-memoize": ">=1.0.0",
     "react": ">=16.8",
     "vite": ">=2.8.6"
   },
@@ -224,6 +226,9 @@
       "optional": true
     },
     "babel-plugin-macros": {
+      "optional": true
+    },
+    "proxy-memoize": {
       "optional": true
     },
     "react": {

--- a/readme.md
+++ b/readme.md
@@ -326,18 +326,23 @@ derive({
 
 #### `proxyWithComputed` util
 
-You can have computed values with dependency tracking with property access.
-Dependency tracking in `proxyWithComputed` overlaps the work in `useSnapshot`.
-React users should prefer using `derive`.
-`proxyWithComputed` works well for some edge cases and for vanilla-js users.
+You can define own computed properties within a proxy.
+Combining with a memoization library such as
+[proxy-memoize](https://github.com/dai-shi/proxy-memoize),
+optimizing invocations of functions is possible.
+
+Be careful not to overuse `proxy-memoize`
+because `proxy-memoize` and `useSnapshot` do similar optimization
+and double optimization may lead to less performance.
 
 ```js
+import memoize from 'proxy-memoize'
 import { proxyWithComputed } from 'valtio/utils'
 
 const state = proxyWithComputed({
   count: 1,
 }, {
-  doubled: snap => snap.count * 2
+  doubled: memoize((snap) => snap.count * 2)
 })
 
 // Computed values accept custom setters too:
@@ -346,7 +351,7 @@ const state2 = proxyWithComputed({
   lastName: 'Baldwin'
 }, {
   fullName: {
-    get: (snap) => snap.firstName + ' ' + snap.lastName,
+    get: memoize((snap) => snap.firstName + ' ' + snap.lastName),
     set: (state, newValue) => { [state.firstName, state.lastName] = newValue.split(' ') },
   }
 })
@@ -355,8 +360,8 @@ const state2 = proxyWithComputed({
 const state = proxyWithComputed({
   count: 1,
 }, {
-  doubled: snap => snap.count * 2,
-  quadrupled: snap => snap.doubled * 2
+  doubled: memoize((snap) => snap.count * 2),
+  quadrupled: memoize((snap) => snap.doubled * 2)
 })
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -327,9 +327,9 @@ derive({
 #### `proxyWithComputed` util
 
 You can define own computed properties within a proxy.
-Combining with a memoization library such as
+By combining with a memoization library such as
 [proxy-memoize](https://github.com/dai-shi/proxy-memoize),
-optimizing invocations of functions is possible.
+optimizing function calls is possible.
 
 Be careful not to overuse `proxy-memoize`
 because `proxy-memoize` and `useSnapshot` do similar optimization

--- a/src/utils/proxyWithComputed.ts
+++ b/src/utils/proxyWithComputed.ts
@@ -1,4 +1,3 @@
-import memoize from 'proxy-memoize'
 import { proxy, snapshot } from '../vanilla'
 
 // Unfortunatly, this doesn't work with tsc.
@@ -71,8 +70,7 @@ export function proxyWithComputed<T extends object, U extends object>(
       set?: (state: T, newValue: U[typeof key]) => void
     }
     const desc: PropertyDescriptor = {}
-    const memoizedGet = memoize(get)
-    desc.get = () => memoizedGet(snapshot(proxyObject))
+    desc.get = () => get(snapshot(proxyObject))
     if (set) {
       desc.set = (newValue) => set(proxyObject, newValue)
     }

--- a/tests/computed.test.tsx
+++ b/tests/computed.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode, Suspense } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { proxy, snapshot, subscribe, useSnapshot } from 'valtio'
 import { addComputed, proxyWithComputed } from 'valtio/utils'
 

--- a/tests/computed.test.tsx
+++ b/tests/computed.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, Suspense } from 'react'
 import { fireEvent, render } from '@testing-library/react'
+import memoize from 'proxy-memoize'
 import { proxy, snapshot, subscribe, useSnapshot } from 'valtio'
 import { addComputed, proxyWithComputed } from 'valtio/utils'
 
@@ -29,7 +30,7 @@ it('simple computed getters', async () => {
       count: 0,
     },
     {
-      doubled: { get: (snap) => computeDouble(snap.count) },
+      doubled: { get: memoize((snap) => computeDouble(snap.count)) },
     }
   )
 
@@ -62,7 +63,7 @@ it('computed getters and setters', async () => {
     },
     {
       doubled: {
-        get: (snap) => computeDouble(snap.count),
+        get: memoize((snap) => computeDouble(snap.count)),
         set: (state, newValue: number) => {
           state.count = newValue / 2
         },
@@ -97,7 +98,7 @@ it('computed setters with object and array', async () => {
     },
     {
       object: {
-        get: (snap) => snap.obj,
+        get: memoize((snap) => snap.obj),
         set: (state, newValue: any) => {
           state.obj = newValue
         },
@@ -268,10 +269,10 @@ it('render computed getter with condition (#435)', async () => {
       filter: '',
     },
     {
-      filtered(snap) {
+      filtered: memoize((snap) => {
         if (!snap.filter) return snap.texts
         return snap.texts.filter((text) => !text.includes(snap.filter))
-      },
+      }),
     }
   )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4594,6 +4594,13 @@ proxy-compare@2.1.0:
   resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.1.0.tgz#5f99b3ed6a265135ce7ec145ce304e6f89b6511b"
   integrity sha512-wapJ3h/w8fRSyPEG0y2WMV+tf9xwvj3nxM6aHVuPEOwKs/t5xLSKZb44ubNTiqq2T6lmEMHEWGMTaU2L6ddaFA==
 
+proxy-memoize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-memoize/-/proxy-memoize-1.0.0.tgz#c5f03f2c7606c0816053f468ad4d505ae526a795"
+  integrity sha512-77q92YWZDBhDETswZiedurVRONR7A6TXb3VmEO9OFaYEpsObV8N9+jy9qX5M2m37998RgYE7YXekWF9M/Q8oSQ==
+  dependencies:
+    proxy-compare "2.1.0"
+
 psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4594,7 +4594,7 @@ proxy-compare@2.1.0:
   resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.1.0.tgz#5f99b3ed6a265135ce7ec145ce304e6f89b6511b"
   integrity sha512-wapJ3h/w8fRSyPEG0y2WMV+tf9xwvj3nxM6aHVuPEOwKs/t5xLSKZb44ubNTiqq2T6lmEMHEWGMTaU2L6ddaFA==
 
-proxy-memoize@1.0.0:
+proxy-memoize@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-memoize/-/proxy-memoize-1.0.0.tgz#c5f03f2c7606c0816053f468ad4d505ae526a795"
   integrity sha512-77q92YWZDBhDETswZiedurVRONR7A6TXb3VmEO9OFaYEpsObV8N9+jy9qX5M2m37998RgYE7YXekWF9M/Q8oSQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4594,7 +4594,7 @@ proxy-compare@2.1.0:
   resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.1.0.tgz#5f99b3ed6a265135ce7ec145ce304e6f89b6511b"
   integrity sha512-wapJ3h/w8fRSyPEG0y2WMV+tf9xwvj3nxM6aHVuPEOwKs/t5xLSKZb44ubNTiqq2T6lmEMHEWGMTaU2L6ddaFA==
 
-proxy-memoize@^1.0.0:
+proxy-memoize@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-memoize/-/proxy-memoize-1.0.0.tgz#c5f03f2c7606c0816053f468ad4d505ae526a795"
   integrity sha512-77q92YWZDBhDETswZiedurVRONR7A6TXb3VmEO9OFaYEpsObV8N9+jy9qX5M2m37998RgYE7YXekWF9M/Q8oSQ==


### PR DESCRIPTION
close #435

This is breaking change in behavior. The API is the same, but a user needs to memoize function on their end. This allows to configure `proxy-memoize`'s options or use some other library, and even they can use without memoization.