### PR TITLE
chore(website): remark plugin adds codesandbox params to urls

### DIFF
--- a/website/lib/mdx.ts
+++ b/website/lib/mdx.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import matter from "gray-matter";
 import path from "path";
 import { getAllFilesRecursively, slugify } from "_utils/file_helpers";
+import { remarkCodeSandboxURLUpdater } from "./remarkCodeSandboxURLUpdater";
 
 // Remark packages
 import remarkGfm from "remark-gfm";
@@ -130,6 +131,7 @@ export async function getDocBySlug(slug: string) {
       // plugins in the future.
       options.remarkPlugins = [
         ...(options.remarkPlugins ?? []),
+        remarkCodeSandboxURLUpdater,
         rehypeSlug,
         [rehypeAutolinkHeadings, { behavior: "wrap" }],
         remarkGfm,

--- a/website/lib/remarkCodeSandboxURLUpdater.ts
+++ b/website/lib/remarkCodeSandboxURLUpdater.ts
@@ -1,0 +1,46 @@
+import { visit, Node } from "unist-util-visit";
+
+const codesandboxBaseUrl = "https://codesandbox.io/s";
+
+type Params = Record<string, string | number>;
+
+const defaultParams = {
+  codemirror: 1,
+  fontsize: 14,
+  hidenavigation: 1,
+  theme: "light",
+  hidedevtools: 1,
+};
+
+interface LinkNode extends Node {
+  url: string;
+  children: {
+    value: string;
+  }[];
+}
+
+export const remarkCodeSandboxURLUpdater = (
+  options = {
+    params: defaultParams,
+  }
+) => {
+  function visitor(linkNode: LinkNode) {
+    if (
+      linkNode.url.startsWith(codesandboxBaseUrl) &&
+      linkNode.children[0]?.value
+    ) {
+      const url = new URL(linkNode.url);
+      Object.entries(options.params).forEach(([key, value]) => {
+        url.searchParams.append(key, value + "");
+      });
+      linkNode.url = url.toString();
+      linkNode.children[0].value = url.toString();
+    }
+  }
+
+  function transform(tree: Node) {
+    visit(tree, "link", visitor);
+  }
+
+  return transform;
+};

--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,6 @@
     "rehype-slug": "^5.0.1",
     "remark-gfm": "^3.0.1",
     "remark-mdx-images": "^1.0.3",
-    "unified": "^10.1.1",
     "valtio": "^1.5.2"
   },
   "devDependencies": {
@@ -40,6 +39,7 @@
     "eslint-config-next": "12.0.7",
     "postcss": "^8.4.5",
     "tailwindcss": "^3.0.12",
-    "typescript": "4.5.4"
+    "typescript": "4.5.4",
+    "unist-util-visit": "^4.1.0"
   }
 }

--- a/website/styles/prism-theme.css
+++ b/website/styles/prism-theme.css
@@ -2,7 +2,7 @@
  * Nord Theme Originally by Arctic Ice Studio
  * https://nordtheme.com
  *
- * Ported for PrismJS by Zane Hitchcoxc (@zwhitchcox) and Gabriel Ramos (@gabrieluizramos)
+ * Ported for PrismJS by Zane Hitchcox (@zwhitchcox) and Gabriel Ramos (@gabrieluizramos)
  */
 
 code[class*="language-"],

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4185,7 +4185,7 @@ unbox-primitive@^1.0.1:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
-unified@^10.0.0, unified@^10.1.0, unified@^10.1.1:
+unified@^10.0.0, unified@^10.1.0:
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.1.tgz#345e349e3ab353ab612878338eb9d57b4dea1d46"
   integrity sha512-v4ky1+6BN9X3pQrOdkFIPWAaeDsHPE1svRDxq7YpTc2plkIqFMwukfqM+l0ewpP9EfwARlt9pPFAeWYhHm8X9w==
@@ -4331,7 +4331,7 @@ unist-util-visit@^3.0.0:
     unist-util-is "^5.0.0"
     unist-util-visit-parents "^4.0.0"
 
-unist-util-visit@^4.0.0:
+unist-util-visit@^4.0.0, unist-util-visit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.0.tgz#f41e407a9e94da31594e6b1c9811c51ab0b3d8f5"
   integrity sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==


### PR DESCRIPTION
Had a go at adding the custom remark plugin to add codepen params to the urls for embeds in the docs as suggested in comments of this PR https://github.com/pmndrs/valtio/pull/396. If this does the job I guess this one is all that is needed.