### PR TITLE
Add note about typescript module augmentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,8 @@ declare module "valtio" {
 }
 ```
 
+Note: this should go in a normal `.ts`/`.tsx` file and not in a `.d.ts` file.
+
 See [#327](https://github.com/pmndrs/valtio/issues/327) for more information.
 </details>
 


### PR DESCRIPTION
If the declaration is in a `.d.ts` file instead then you get the following error:

> Module '"valtio"' has no exported member 'proxy'.ts(2305)

Here's a code sandbox that illustrates the issue:
https://codesandbox.io/s/react-typescript-forked-8ijjyy?file=/src/App.tsx