### PR TITLE
fix(vanilla): Cancel promise on unsubscribe

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -222,6 +222,7 @@ export function subscribe<T extends object>(
     console.warn('Please use proxy object')
   }
   let promise: Promise<void> | undefined
+  let active = true;
   const ops: Op[] = []
   const listener: Listener = (op) => {
     ops.push(op)
@@ -232,12 +233,15 @@ export function subscribe<T extends object>(
     if (!promise) {
       promise = Promise.resolve().then(() => {
         promise = undefined
-        callback(ops.splice(0))
+        if (active) {
+          callback(ops.splice(0))
+        }
       })
     }
   }
   ;(proxyObject as any)[LISTENERS].add(listener)
   return () => {
+    active = false;
     ;(proxyObject as any)[LISTENERS].delete(listener)
   }
 }


### PR DESCRIPTION
I'm seeing Errors like this in my React-App:

Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.

These occur both with Firefox and Chromium.

I think they are caused because a component is unmounted in the tick right between promise creation and resolution, so deleting the listener is not enough tho prevent the callback from being invoked.

The proposed change removes the errors.