### PR TITLE
fix(website): Remove misleading label

### DIFF
--- a/website/components/LandingPage/CodeExample.tsx
+++ b/website/components/LandingPage/CodeExample.tsx
@@ -42,10 +42,7 @@ export const CodeExample = () => {
     <div className="code-container">
       <div className="code-container-inner">
         <div className="duration-changer">
-          <h3 className="text-xl font-bold">
-            {snap.dur}
-            <small className="font-light"> sec</small>
-          </h3>
+          <h3 className="text-xl font-bold">{snap.dur}</h3>
           <div>
             <button
               className="counter"

--- a/website/styles/landing-page.css
+++ b/website/styles/landing-page.css
@@ -68,6 +68,15 @@ html {
     left: 0;
     right: 0;
   }
+
+  .prism-code.language-jsx {
+    border-radius: 0;
+  }
+
+  /* center code when pre is full-screen*/
+  pre {
+    padding-left: calc(100% - 800px) !important;
+  }
 }
 
 .code-container-inner {


### PR DESCRIPTION
- in the animation the count presents to 1sec but not in the setInterval. Removing this to reduce confusion.
- center code and remove border radius on small screen when the code block is full width