### PR TITLE
fix(types): export INTERNAL interface

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -10,6 +10,7 @@ import {
 // The following is a workaround until ESM is supported.
 import useSyncExternalStoreExports from 'use-sync-external-store/shim'
 import { snapshot, subscribe } from './vanilla'
+import type { INTERNAL_AsRef } from './vanilla'
 
 const { useSyncExternalStore } = useSyncExternalStoreExports
 
@@ -24,13 +25,10 @@ const { useSyncExternalStore } = useSyncExternalStoreExports
 //   type Snapshot<T extends object> = ReturnType<SnapshotWrapper<T>['fn']>
 //
 // Using copy-paste types for now:
-interface AsRef {
-  $$valtioRef: true
-}
 type AnyFunction = (...args: any[]) => any
 type Snapshot<T> = T extends AnyFunction
   ? T
-  : T extends AsRef
+  : T extends INTERNAL_AsRef
   ? T
   : T extends Promise<infer V>
   ? Snapshot<V>

--- a/src/utils/proxyWithComputed.ts
+++ b/src/utils/proxyWithComputed.ts
@@ -1,4 +1,5 @@
 import { proxy, snapshot } from '../vanilla'
+import type { INTERNAL_AsRef } from '../vanilla'
 
 // Unfortunately, this doesn't work with tsc.
 // Hope to find a solution to make this work.
@@ -11,13 +12,10 @@ import { proxy, snapshot } from '../vanilla'
 //   type Snapshot<T extends object> = ReturnType<SnapshotWrapper<T>['fn']>
 //
 // Using copy-paste types for now:
-interface AsRef {
-  $$valtioRef: true
-}
 type AnyFunction = (...args: any[]) => any
 type Snapshot<T> = T extends AnyFunction
   ? T
-  : T extends AsRef
+  : T extends INTERNAL_AsRef
   ? T
   : T extends Promise<infer V>
   ? Snapshot<V>

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -7,13 +7,17 @@ const HANDLER = __DEV__ ? Symbol('HANDLER') : Symbol()
 const PROMISE_RESULT = __DEV__ ? Symbol('PROMISE_RESULT') : Symbol()
 const PROMISE_ERROR = __DEV__ ? Symbol('PROMISE_ERROR') : Symbol()
 
-interface AsRef {
+/**
+ * This not a public API.
+ * It can be changed without notice.
+ */
+export interface INTERNAL_AsRef {
   $$valtioRef: true
 }
 const refSet = new WeakSet()
-export function ref<T extends object>(o: T): T & AsRef {
+export function ref<T extends object>(o: T): T & INTERNAL_AsRef {
   refSet.add(o)
-  return o as T & AsRef
+  return o as T & INTERNAL_AsRef
 }
 
 const isObject = (x: unknown): x is object =>
@@ -247,7 +251,7 @@ export function subscribe<T extends object>(
 type AnyFunction = (...args: any[]) => any
 type Snapshot<T> = T extends AnyFunction
   ? T
-  : T extends AsRef
+  : T extends INTERNAL_AsRef
   ? T
   : T extends Promise<infer V>
   ? Snapshot<V>


### PR DESCRIPTION
#474 changed type aliases to interfaces.
I learned this can cause issues with public types. https://github.com/pmndrs/jotai/issues/1261
This PR export an interface with `INTERNAL_` prefix.
This should cover some edge use cases. https://github.com/pmndrs/valtio/issues/292#issuecomment-986107595