### PR TITLE
docs: fix inline code format

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Two kinds of proxies are used for different purposes:
 </details>
 
 <details>
-<summary>Use of `this` is for expert users.</summary>
+<summary>Use of <code>this</code> is for expert users.</summary>
 
 Valtio tries best to handle `this` behavior
 but it's hard to understand without familiarity.


### PR DESCRIPTION
## Related Issues

N/A

## Summary

Markdown does not work when interleaved with HTML, inline code should use `<code>` instead of backticks.

## Check List

- [ ] `yarn run prettier` for formatting code and docs
