### PR TITLE
chore(docs): add component state guide

### DIFF
--- a/docs/guides/component-state.mdx
+++ b/docs/guides/component-state.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Component state'
+section: 'Advanced'
+description: 'Isolate component state with useRef'
+---
+
+# Component state
+
+To isolate component state for reusability, Valtio must live in the React lifecycle. You can wrap a `proxy` in a ref, passing it with props or context.
+
+```jsx
+import { createContext, useContext } from 'react'
+import { proxy, useSnapshot } from 'valtio'
+
+const MyContext = createContext()
+
+const MyProvider = ({ children }) => {
+  const state = useRef(proxy({ count: 0 })).current
+  return <MyContext.Provider value={state}>{children}</MyContext.Provider>
+}
+
+const MyCounter = () => {
+  const state = useContext(MyContext)
+  const snap = useSnapshot(state)
+  return (
+    <>
+      {snap.count} <button onClick={() => ++state.count}>+1</button>
+    </>
+  )
+}
+```
+
+If you are not happy with useRef usage, consider [use-constant](https://www.npmjs.com/package/use-constant) instead.
+You may also create custom hooks wrapping useContext and optionally useSnapshot.
+
+## Codesandbox example
+
+https://codesandbox.io/s/valtio-component-ye5tbg?file=/src/App.tsx

--- a/website/lib/mdx.ts
+++ b/website/lib/mdx.ts
@@ -244,7 +244,7 @@ export function getDocsNav(): NavigationTree {
   const pages = getDocsMap();
   return {
     Introduction: [pages["getting-started"]],
-    Guides: [pages["async"]],
+    Guides: [pages["async"], pages["component-state"]],
     API: {
       Basic: [pages["proxy"], pages["useSnapshot"]],
       Advanced: [pages["ref"], pages["subscribe"], pages["snapshot"]],


### PR DESCRIPTION
## Summary

Adds example from wiki using context for isolated component state to website docs.

## Check List

- [ x] `yarn run prettier` for formatting code and docs
