### PR TITLE
fix: subscribers should not be called after unsubscribe

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -275,7 +275,9 @@ export function subscribe<T extends object>(
     if (!promise) {
       promise = Promise.resolve().then(() => {
         promise = undefined
-        callback(ops.splice(0))
+        if ((proxyObject as any)[LISTENERS].has(listener)) {
+          callback(ops.splice(0))
+        }
       })
     }
   }

--- a/tests/subscribe.test.tsx
+++ b/tests/subscribe.test.tsx
@@ -44,7 +44,7 @@ describe('subscribe', () => {
     const obj = proxy({ count: 0 })
     const handler = jest.fn()
 
-    const unsubscribeA = subscribe(obj, () => {
+    const _unsubscribeA = subscribe(obj, () => {
       unsubscribeB()
     })
 

--- a/tests/subscribe.test.tsx
+++ b/tests/subscribe.test.tsx
@@ -40,6 +40,22 @@ describe('subscribe', () => {
     expect(handler).toBeCalledTimes(0)
   })
 
+  it('should be able to unsubscribe from a subscriber', async () => {
+    const obj = proxy({ count: 0 })
+    const handler = jest.fn()
+
+    const unsubscribeA = subscribe(obj, () => {
+      unsubscribeB()
+    })
+
+    const unsubscribeB = subscribe(obj, handler)
+
+    obj.count += 1
+
+    await Promise.resolve()
+    expect(handler).toBeCalledTimes(0)
+  })
+
   it('should call subscription of object property', async () => {
     const obj = proxy({ nested: { count: 0 } })
     const handler = jest.fn()


### PR DESCRIPTION
## Related Issues

N/A

## Summary

There is an edge case in the subscribe notification logic which can cause a subscriber to be called after it has been unsubscribed.

To reproduce the issue:
  1. create a subscription "A"
  2. create a subscription "B"
  3. in the listener for "A", unsubscribe "B"

Expected result:
- "B" is never called (assuming listeners are processed in the order they were added)

Actual result:
- "B" is called once, and then never again

The fix is to check whether the subscription has been unsubscribed before firing the subscription's notification callback.

We ran into issues with this causing a "state update after unmount" error in our React app:
```
Can't perform a React state update on an unmounted component. This is a no-op, but 
it indicates a memory leak in your application. To fix, cancel all subscriptions and 
asynchronous tasks in a useEffect cleanup function.
```

and this fixes the issue for us.

## Check List

- [x] `yarn run prettier` for formatting code and docs
