### PR TITLE
fix(build): test with old typescript versions and fix for old ts versions

### DIFF
--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -1,0 +1,53 @@
+name: Test Old TypeScript
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  test_matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        typescript:
+          - 4.8.4
+          - 4.7.4
+          - 4.6.4
+          - 4.5.5
+          - 4.4.4
+          - 4.3.5
+          - 4.2.3
+          - 4.1.5
+          - 4.0.5
+          - 3.9.7
+          - 3.8.3
+          - 3.7.5
+          - 3.6.3
+          - 3.5.1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: yarn
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - run: yarn install --frozen-lockfile --check-files
+      - run: yarn build
+      - name: Patch for Old TS
+        run: |
+          sed -i~ '1s/^/import React from "react";/' tests/*.tsx
+          sed -i~ "s/\/\/ @ts-expect-error.*\[LATEST-TS-ONLY\]//" tests/*.tsx
+          sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
+          sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
+          sed -i~ "s/\"exactOptionalPropertyTypes\": true,//" tsconfig.json
+          sed -i~ "s/\"jotai\": \[\".\/src\/index.ts\"\],/\"jotai\": [\".\/dist\/index.d.ts\"],/" tsconfig.json
+          sed -i~ "s/\"jotai\/\*\": \[\".\/src\/\*.ts\"\]/\"jotai\/*\": [\".\/dist\/*.d.ts\"]/" tsconfig.json
+          sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
+      - name: Test ${{ matrix.typescript }}
+        run: |
+          yarn add -D typescript@${{ matrix.typescript }}
+          yarn add -D @types/jest@27.4.1
+          yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -50,4 +50,5 @@ jobs:
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
           yarn add -D @types/jest@27.4.1
+          rm -r node_modules/@types/jsdom node_modules/parse5
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -21,12 +21,6 @@ jobs:
           - 4.3.5
           - 4.2.3
           - 4.1.5
-          - 4.0.5
-          - 3.9.7
-          - 3.8.3
-          - 3.7.5
-          - 3.6.3
-          - 3.5.1
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -43,8 +37,8 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/\"exactOptionalPropertyTypes\": true,//" tsconfig.json
-          sed -i~ "s/\"jotai\": \[\".\/src\/index.ts\"\],/\"jotai\": [\".\/dist\/index.d.ts\"],/" tsconfig.json
-          sed -i~ "s/\"jotai\/\*\": \[\".\/src\/\*.ts\"\]/\"jotai\/*\": [\".\/dist\/*.d.ts\"]/" tsconfig.json
+          sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/index.d.ts\"],/" tsconfig.json
+          sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
       - name: Test ${{ matrix.typescript }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -49,8 +49,8 @@ jobs:
           sed -i~ '1s/^/import React from "react";/' tests/*.tsx
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
-          yarn json -I -f package.json -e "this.resolutions['@types/jest']='27.4.1'; this.resolutions['pretty-format']='27.5.1'; this.resolutions['@types/prettier']='2.4.4';"
-          yarn add -D @types/jest@27.4.1 pretty-format@27.5.1 @types/prettier@2.4.4
+          yarn json -I -f package.json -e "this.resolutions['@types/jest']='26.0.14'; this.resolutions['pretty-format']='26.6.2'; this.resolutions['@types/prettier']='2.4.2';"
+          yarn add -D @types/jest@26.0.14 pretty-format@26.6.2 @types/prettier@2.4.2
           rm -r tests/macro-vite.*
       - name: Test ${{ matrix.typescript }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -43,8 +43,8 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/\"exactOptionalPropertyTypes\": true,//" tsconfig.json
-          sed -i~ "s/\"jotai\": \[\".\/src\/index.ts\"\],/\"jotai\": [\".\/dist\/index.d.ts\"],/" tsconfig.json
-          sed -i~ "s/\"jotai\/\*\": \[\".\/src\/\*.ts\"\]/\"jotai\/*\": [\".\/dist\/*.d.ts\"]/" tsconfig.json
+          sed -i~ "s/\"valtio\": \[\".\/src\/index.ts\"\],/\"valtio\": [\".\/dist\/index.d.ts\"],/" tsconfig.json
+          sed -i~ "s/\"valtio\/\*\": \[\".\/src\/\*.ts\"\]/\"valtio\/*\": [\".\/dist\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
       - name: Test ${{ matrix.typescript }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -50,8 +50,9 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4
+          rm -r tests/macro-vite.*
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -r node_modules/@types/jsdom node_modules/parse5 node_modules/@types/babel-plugin-tester/node_modules/@types/prettier
+          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/babel-plugin-tester/node_modules/@types/prettier
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -54,5 +54,5 @@ jobs:
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/babel-plugin-tester/node_modules/@types/prettier
+          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/babel-plugin-tester/node_modules/@types/prettier node_modules/@testing-library/dom/node_modules/pretty-format node_modules/@types/jest/node_modules/jest-diff
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -49,8 +49,7 @@ jobs:
           sed -i~ '1s/^/import React from "react";/' tests/*.tsx
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
-          sed -i~ "s/^}/,\"skipLibCheck\":true}/" tsconfig.json
-          yarn add -D @types/jest@27.4.1
+          yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -49,9 +49,10 @@ jobs:
           sed -i~ '1s/^/import React from "react";/' tests/*.tsx
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
+          sed -i~ "s/^import type /import /" node_modules/**/*.d.ts
           yarn add -D @types/jest@27.4.1
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -r node_modules/@types/jsdom node_modules/parse5 node_modules/@types/prettier
+          rm -r node_modules/@types/jsdom node_modules/parse5
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -49,7 +49,7 @@ jobs:
           sed -i~ '1s/^/import React from "react";/' tests/*.tsx
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
-          yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4
+          yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4 @types/babel-plugin-tester@9.0.4
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -49,7 +49,8 @@ jobs:
           sed -i~ '1s/^/import React from "react";/' tests/*.tsx
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
-          yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4 @types/babel-plugin-tester@9.0.4
+          yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4
+          rm -r node_modules/@types/babel-plugin-tester/node_modules/@types/prettier
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -43,8 +43,8 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/\"exactOptionalPropertyTypes\": true,//" tsconfig.json
-          sed -i~ "s/\"valtio\": \[\".\/src\/index.ts\"\],/\"valtio\": [\".\/dist\/index.d.ts\"],/" tsconfig.json
-          sed -i~ "s/\"valtio\/\*\": \[\".\/src\/\*.ts\"\]/\"valtio\/*\": [\".\/dist\/*.d.ts\"]/" tsconfig.json
+          sed -i~ "s/\"valtio\": \[\".\/src\/index.ts\"\],/\"valtio\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
+          sed -i~ "s/\"valtio\/\*\": \[\".\/src\/\*.ts\"\]/\"valtio\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
       - name: Test ${{ matrix.typescript }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -38,17 +38,20 @@ jobs:
       - run: yarn build
       - name: Patch for Old TS
         run: |
-          sed -i~ '1s/^/import React from "react";/' tests/*.tsx
           sed -i~ "s/\/\/ @ts-expect-error.*\[LATEST-TS-ONLY\]//" tests/*.tsx
-          sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
-          sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/\"exactOptionalPropertyTypes\": true,//" tsconfig.json
           sed -i~ "s/\"valtio\": \[\".\/src\/index.ts\"\],/\"valtio\": [\".\/dist\/ts3.4\/index.d.ts\"],/" tsconfig.json
           sed -i~ "s/\"valtio\/\*\": \[\".\/src\/\*.ts\"\]/\"valtio\/*\": [\".\/dist\/ts3.4\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
+      - name: Patch for Older TS
+        if: ${{ matrix.typescript == '4.0.5' || startsWith(matrix.typescript, '3.') }}
+        run: |
+          sed -i~ '1s/^/import React from "react";/' tests/*.tsx
+          sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
+          sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
+          yarn add -D @types/jest@27.4.1
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          yarn add -D @types/jest@27.4.1
           rm -r node_modules/@types/jsdom node_modules/parse5 node_modules/@types/prettier
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -25,8 +25,6 @@ jobs:
           - 3.9.7
           - 3.8.3
           - 3.7.5
-          - 3.6.3
-          - 3.5.1
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -49,8 +47,8 @@ jobs:
           sed -i~ '1s/^/import React from "react";/' tests/*.tsx
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
-          yarn json -I -f package.json -e "this.resolutions['@types/jest']='26.0.14'; this.resolutions['pretty-format']='26.6.2'; this.resolutions['@types/prettier']='2.4.2';"
-          yarn add -D @types/jest@26.0.14 pretty-format@26.6.2 @types/prettier@2.4.2
+          yarn json -I -f package.json -e "this.resolutions['@types/jest']='26.0.14'; this.resolutions['pretty-format']='25.5.0'; this.resolutions['@types/prettier']='2.4.2';"
+          yarn add -D @types/jest@26.0.14 pretty-format@25.5.0 @types/prettier@2.4.2
           rm -r tests/macro-vite.*
       - name: Test ${{ matrix.typescript }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -49,10 +49,11 @@ jobs:
           sed -i~ '1s/^/import React from "react";/' tests/*.tsx
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
-          yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4
+          yarn json -I -f package.json -e "this.resolutions['@types/jest']='27.4.1'; this.resolutions['pretty-format']='27.5.1';"
+          yarn add -D @types/jest@27.4.1 pretty-format@27.5.1
           rm -r tests/macro-vite.*
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -fr node_modules/@types/jsdom node_modules/parse5 node_modules/@types/babel-plugin-tester/node_modules/@types/prettier node_modules/@testing-library/dom/node_modules/pretty-format node_modules/@types/jest/node_modules/jest-diff
+          rm -r node_modules/@types/jsdom node_modules/parse5 node_modules/@types/prettier
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -21,6 +21,12 @@ jobs:
           - 4.3.5
           - 4.2.3
           - 4.1.5
+          - 4.0.5
+          - 3.9.7
+          - 3.8.3
+          - 3.7.5
+          - 3.6.3
+          - 3.5.1
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -37,8 +43,8 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           sed -i~ "s/\"exactOptionalPropertyTypes\": true,//" tsconfig.json
-          sed -i~ "s/\"jotai\": \[\"\.\/src\/index\.ts\"\],/\"jotai\": [\".\/dist\/index.d.ts\"],/" tsconfig.json
-          sed -i~ "s/\"jotai\/\*\": \[\"\.\/src\/\*\.ts\"\]/\"jotai\/*\": [\".\/dist\/*.d.ts\"]/" tsconfig.json
+          sed -i~ "s/\"jotai\": \[\".\/src\/index.ts\"\],/\"jotai\": [\".\/dist\/index.d.ts\"],/" tsconfig.json
+          sed -i~ "s/\"jotai\/\*\": \[\".\/src\/\*.ts\"\]/\"jotai\/*\": [\".\/dist\/*.d.ts\"]/" tsconfig.json
           sed -i~ "s/\"include\": .*/\"include\": [\"src\/types.d.ts\", \"dist\/**\/*\", \"tests\/**\/*\"],/" tsconfig.json
       - name: Test ${{ matrix.typescript }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -50,9 +50,8 @@ jobs:
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
           yarn add -D @types/jest@27.4.1 @types/prettier@2.4.4
-          rm -r node_modules/@types/babel-plugin-tester/node_modules/@types/prettier
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -r node_modules/@types/jsdom node_modules/parse5
+          rm -r node_modules/@types/jsdom node_modules/parse5 node_modules/@types/babel-plugin-tester/node_modules/@types/prettier
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -49,11 +49,11 @@ jobs:
           sed -i~ '1s/^/import React from "react";/' tests/*.tsx
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
-          yarn json -I -f package.json -e "this.resolutions['@types/jest']='27.4.1'; this.resolutions['pretty-format']='27.5.1';"
-          yarn add -D @types/jest@27.4.1 pretty-format@27.5.1
+          yarn json -I -f package.json -e "this.resolutions['@types/jest']='27.4.1'; this.resolutions['pretty-format']='27.5.1'; this.resolutions['@types/prettier']='2.4.4';"
+          yarn add -D @types/jest@27.4.1 pretty-format@27.5.1 @types/prettier@2.4.4
           rm -r tests/macro-vite.*
       - name: Test ${{ matrix.typescript }}
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
-          rm -r node_modules/@types/jsdom node_modules/parse5 node_modules/@types/prettier
+          rm -r node_modules/@types/jsdom node_modules/parse5
           yarn tsc --noEmit

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -49,7 +49,7 @@ jobs:
           sed -i~ '1s/^/import React from "react";/' tests/*.tsx
           sed -i~ "s/\"jsx\": \"react-jsx\",/\"jsx\": \"react\",/" tsconfig.json
           sed -i~ "s/\"noUncheckedIndexedAccess\": true,//" tsconfig.json
-          sed -i~ "s/^import type /import /" node_modules/**/*.d.ts
+          sed -i~ "s/^}/,\"skipLibCheck\":true}/" tsconfig.json
           yarn add -D @types/jest@27.4.1
       - name: Test ${{ matrix.typescript }}
         run: |

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -50,5 +50,5 @@ jobs:
         run: |
           yarn add -D typescript@${{ matrix.typescript }}
           yarn add -D @types/jest@27.4.1
-          rm -r node_modules/@types/jsdom node_modules/parse5
+          rm -r node_modules/@types/jsdom node_modules/parse5 node_modules/@types/prettier
           yarn tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
     "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined;\"",
-    "patch-ts3.4": "shx sed -i 's/^declare type Snapshot<T> =/declare type Snapshot<T> = T;declare type _Snapshot<T> =/' 'dist/ts3.4/**/*.d.ts'"
+    "patch-ts3.4": "shx sed -i 's/extends Promise<infer V> \\? Snapshot<V>/extends Promise<infer V> ? V/' 'dist/ts3.4/**/*.d.ts'; shx sed -i 's/readonly \\[K in keyof T\\]: Snapshot<T\\[K\\]>/readonly [K in keyof T]: T[K]/' 'dist/ts3.4/**/*.d.ts'"
   },
   "engines": {
     "node": ">=12.7.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "build:utils": "rollup -c --config-utils",
     "build:macro": "rollup -c --config-macro",
     "build:macro-vite": "rollup -c --config-macro_vite",
-    "postbuild": "yarn copy",
+    "postbuild": "yarn copy && yarn patch-ts3.4",
     "prettier": "prettier '*.{js,json,md}' '{src,tests,docs}/**/*.{ts,tsx,md,mdx}' --write",
     "prettier:ci": "prettier '*.{js,json,md}' '{src,tests,docs}/**/*.{ts,tsx,md,mdx}' --list-different",
     "eslint": "eslint --fix '*.{js,json}' '{src,tests}/**/*.{ts,tsx}'",
@@ -71,7 +71,8 @@
     "test:ci": "jest",
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
-    "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined;\""
+    "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined;\"",
+    "patch-ts3.4": "shx sed -i 's/^declare type Snapshot<T> =/declare type Snapshot<T> = T;declare type _Snapshot<T> =/' dist/ts3.4/**/*.d.ts"
   },
   "engines": {
     "node": ">=12.7.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
     "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined;\"",
-    "patch-ts3.4": "shx sed -i 's/^declare type Snapshot<T> =/declare type Snapshot<T> = T;declare type _Snapshot<T> =/' dist/ts3.4/**/*.d.ts"
+    "patch-ts3.4": "shx sed -i 's/^declare type Snapshot<T> =/declare type Snapshot<T> = T;declare type _Snapshot<T> =/' 'dist/ts3.4/**/*.d.ts'"
   },
   "engines": {
     "node": ">=12.7.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
     "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined;\"",
-    "patch-ts3.4": "shx sed -i 's/extends Promise<infer V> \\? Snapshot<V>/extends Promise<infer V> ? V/' 'dist/ts3.4/**/*.d.ts'; shx sed -i 's/readonly \\[K in keyof T\\]: Snapshot<T\\[K\\]>/readonly [K in keyof T]: T[K]/' 'dist/ts3.4/**/*.d.ts'"
+    "patch-ts3.4": "shx sed -i 's/^declare type Snapshot<T> =/declare type Snapshot<T> = T extends AnyFunction ? T : T extends AsRef ? T : T extends Promise<infer V> ? Snapshot2<V> : { readonly [K in keyof T]: Snapshot2<T[K]> }; type Snapshot2<T> = T extends AnyFunction ? T : T extends AsRef ? T : T extends Promise<infer V> ? V : { readonly [K in keyof T]: T[K] };declare type _Snapshot<T> =/' 'dist/ts3.4/**/*.d.ts'"
   },
   "engines": {
     "node": ">=12.7.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "build:utils": "rollup -c --config-utils",
     "build:macro": "rollup -c --config-macro",
     "build:macro-vite": "rollup -c --config-macro_vite",
-    "postbuild": "yarn copy && yarn patch-ts3.4",
+    "postbuild": "yarn copy && yarn patch-macro-vite && yarn patch-ts3.4",
     "prettier": "prettier '*.{js,json,md}' '{src,tests,docs}/**/*.{ts,tsx,md,mdx}' --write",
     "prettier:ci": "prettier '*.{js,json,md}' '{src,tests,docs}/**/*.{ts,tsx,md,mdx}' --list-different",
     "eslint": "eslint --fix '*.{js,json}' '{src,tests}/**/*.{ts,tsx}'",
@@ -72,6 +72,7 @@
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
     "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && downlevel-dts dist dist/ts3.4 && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined;\"",
+    "patch-macro-vite": "shx cp dist/esm/macro/vite.d.ts dist/macro/ && shx mkdir dist/ts3.4/macro && shx cp dist/ts3.4/esm/macro/vite.d.ts dist/ts3.4/macro/",
     "patch-ts3.4": "shx sed -i 's/^declare type Snapshot<T> =/declare type Snapshot<T> = T extends AnyFunction ? T : T extends AsRef ? T : T extends Promise<infer V> ? Snapshot2<V> : { readonly [K in keyof T]: Snapshot2<T[K]> }; type Snapshot2<T> = T extends AnyFunction ? T : T extends AsRef ? T : T extends Promise<infer V> ? V : { readonly [K in keyof T]: T[K] };declare type _Snapshot<T> =/' 'dist/ts3.4/**/*.d.ts'"
   },
   "engines": {


### PR DESCRIPTION
In https://github.com/pmndrs/zustand/pull/1348, I added a workflow to test against old ts versions. Let's follow it.