### PR TITLE
fix(utils): Return accurate data at toJSON of proxySet/proxyMap

### DIFF
--- a/src/utils/proxyMap.ts
+++ b/src/utils/proxyMap.ts
@@ -70,7 +70,7 @@ export function proxyMap<K, V>(
       return this.data.length
     },
     toJSON() {
-      return {}
+      return new Map(this.data)
     },
     forEach(cb) {
       this.data.forEach((p) => {

--- a/src/utils/proxyMap.ts
+++ b/src/utils/proxyMap.ts
@@ -92,7 +92,6 @@ export function proxyMap<K, V>(
     [Symbol.iterator]() {
       return this.entries()
     },
-    __proto__: Map.prototype,
   })
 
   Object.defineProperties(map, {

--- a/src/utils/proxyMap.ts
+++ b/src/utils/proxyMap.ts
@@ -92,6 +92,7 @@ export function proxyMap<K, V>(
     [Symbol.iterator]() {
       return this.entries()
     },
+    __proto__: Map.prototype,
   })
 
   Object.defineProperties(map, {

--- a/src/utils/proxySet.ts
+++ b/src/utils/proxySet.ts
@@ -60,7 +60,7 @@ export function proxySet<T>(initialValues?: Iterable<T> | null): Set<T> {
       return 'Set'
     },
     toJSON() {
-      return {}
+      return new Set(this.data)
     },
     [Symbol.iterator]() {
       return this.data[Symbol.iterator]()

--- a/src/utils/proxySet.ts
+++ b/src/utils/proxySet.ts
@@ -76,6 +76,7 @@ export function proxySet<T>(initialValues?: Iterable<T> | null): Set<T> {
       // array.entries returns [index, value] while Set [value, value]
       return new Set(this.data).entries()
     },
+    __proto__: Set.prototype,
   })
 
   Object.defineProperties(set, {

--- a/src/utils/proxySet.ts
+++ b/src/utils/proxySet.ts
@@ -76,7 +76,6 @@ export function proxySet<T>(initialValues?: Iterable<T> | null): Set<T> {
       // array.entries returns [index, value] while Set [value, value]
       return new Set(this.data).entries()
     },
-    __proto__: Set.prototype,
   })
 
   Object.defineProperties(set, {

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -103,12 +103,6 @@ const inputValues = [
 
 describe('features parity with native Map', () => {
   initialValues.forEach(({ name, value }) => {
-    it(`is an instance of Map`, () => {
-      const map = proxyMap(value as any)
-
-      expect(map).toBeInstanceOf(Map)
-    })
-
     it(`Support Map operations on ${name}`, () => {
       const map = proxyMap(value as any)
       const nativeMap = new Map(value as any)

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -103,6 +103,12 @@ const inputValues = [
 
 describe('features parity with native Map', () => {
   initialValues.forEach(({ name, value }) => {
+    it(`is an instance of Map`, () => {
+      const map = proxyMap(value as any)
+
+      expect(map).toBeInstanceOf(Map)
+    })
+
     it(`Support Map operations on ${name}`, () => {
       const map = proxyMap(value as any)
       const nativeMap = new Map(value as any)

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -129,6 +129,12 @@ describe('features parity with native Map', () => {
         )
         expect(JSON.stringify(map)).toStrictEqual(JSON.stringify(nativeMap))
 
+        JSON.stringify(map, (_, mapV) => {
+          JSON.stringify(nativeMap, (_, nativeMapV) => {
+            expect(mapV).toStrictEqual(nativeMapV)
+          })
+        })
+
         // cover loops
         const handleForEach = jest.fn()
         const handleForOf = jest.fn()

--- a/tests/proxySet.test.tsx
+++ b/tests/proxySet.test.tsx
@@ -106,12 +106,6 @@ const inputValues = [
 
 describe('features parity with native Set', () => {
   initialValues.forEach(({ name, value }) => {
-    it(`is an instance of Set`, () => {
-      const set = proxySet<unknown>(value)
-
-      expect(set).toBeInstanceOf(Set)
-    })
-
     it(`support Set operations on ${name}`, () => {
       const set = proxySet<unknown>(value)
       const nativeSet = new Set<unknown>(value)

--- a/tests/proxySet.test.tsx
+++ b/tests/proxySet.test.tsx
@@ -132,6 +132,12 @@ describe('features parity with native Set', () => {
         )
         expect(JSON.stringify(set)).toStrictEqual(JSON.stringify(nativeSet))
 
+        JSON.stringify(set, (_, setV) => {
+          JSON.stringify(nativeSet, (_, nativeSetV) => {
+            expect(setV).toStrictEqual(nativeSetV)
+          })
+        })
+
         // cover loops
         const handleForEach = jest.fn()
         const handleForOf = jest.fn()

--- a/tests/proxySet.test.tsx
+++ b/tests/proxySet.test.tsx
@@ -106,6 +106,12 @@ const inputValues = [
 
 describe('features parity with native Set', () => {
   initialValues.forEach(({ name, value }) => {
+    it(`is an instance of Set`, () => {
+      const set = proxySet<unknown>(value)
+
+      expect(set).toBeInstanceOf(Set)
+    })
+
     it(`support Set operations on ${name}`, () => {
       const set = proxySet<unknown>(value)
       const nativeSet = new Set<unknown>(value)


### PR DESCRIPTION
## Summary

**Please read https://github.com/pmndrs/valtio/pull/567#issuecomment-1273657366.**

~~Although `proxySet` and `proxyMap` have feature parity with native `Set` and `Map`, these proxies are not caught by `instanceof Set` and/or `instanceof Map`. This can be a problem when we want to validate whether a certain proxied value is either a `Set` or a `Map`, because prior to this patch, these proxies are not understood as being actual instances of `Set`/`Map`. Check out these examples:~~

```ts
if (proxySet([1, 2, 3]) instanceof Set) {
  // this code will never run because this condition will always be `false`
}

if (proxyMap() instanceof Map) {
  // this code will never run because this condition will always be `false`
}
```

~~After this patch, the conditions above will be satisfied and return `true`.~~

~~**NOTE:** I don't know if `proxySet` and `proxyMap` are actually expected to _not_ be understood as an instance of `Set`/`Map`. If that's the case, please feel free to dismiss this Pull Request although I would appreciate an explanation as to why and if there's any way I can have my `Set`/`Map` proxies to get caught by `instanceof <Set|Map>` at implementation-level.~~

---

~~To give you a use-case: I am using [`teleport-javascript`](https://github.com/postmanlabs/teleport-javascript) to serialize data. And it relies on `instanceof <Set|Map>` to be able to serialize them: https://github.com/postmanlabs/teleport-javascript/blob/master/index.js#L239. Because valtio's `proxySet`/`proxyMap` don't pass through these conditions, `teleport-javascript` is not able to serialize them.~~

## Check List
- [x] `yarn run prettier` for formatting code and docs
