### PR TITLE
fix(react): a workaround for missing named exports

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -1,7 +1,6 @@
 /// <reference types="react/experimental" />
 
-import {
-  experimental_use as use,
+import ReactExports, {
   useCallback,
   useDebugValue,
   useEffect,
@@ -23,6 +22,7 @@ import { snapshot, subscribe } from './vanilla'
 import type { INTERNAL_Snapshot as Snapshot } from './vanilla'
 
 const { useSyncExternalStore } = useSyncExternalStoreExports
+const use = ReactExports.experimental_use
 
 // customized version of affectedToPathList
 // we need to avoid invoking getters

--- a/src/react.ts
+++ b/src/react.ts
@@ -21,8 +21,8 @@ import useSyncExternalStoreExports from 'use-sync-external-store/shim'
 import { snapshot, subscribe } from './vanilla'
 import type { INTERNAL_Snapshot as Snapshot } from './vanilla'
 
-const { useSyncExternalStore } = useSyncExternalStoreExports
 const use = ReactExports.experimental_use
+const { useSyncExternalStore } = useSyncExternalStoreExports
 
 // customized version of affectedToPathList
 // we need to avoid invoking getters


### PR DESCRIPTION
close #572 