### PR TITLE
fix(build): Clean up peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,29 +217,9 @@
     "date-fns": "2.27.0"
   },
   "peerDependencies": {
-    "@babel/helper-module-imports": ">=7.12",
-    "@babel/types": ">=7.13",
-    "aslemammad-vite-plugin-macro": ">=1.0.0-alpha.1",
-    "babel-plugin-macros": ">=3.0",
-    "react": ">=16.8",
-    "vite": ">=2.8.6"
+    "react": ">=16.8"
   },
   "peerDependenciesMeta": {
-    "vite": {
-      "optional": true
-    },
-    "aslemammad-vite-plugin-macro": {
-      "optional": true
-    },
-    "@babel/helper-module-imports": {
-      "optional": true
-    },
-    "@babel/types": {
-      "optional": true
-    },
-    "babel-plugin-macros": {
-      "optional": true
-    },
     "react": {
       "optional": true
     }


### PR DESCRIPTION
Clean up peer dependencies which are not actually peer deps and they cause non-deterministic pnpm behavior with projects consuming valtio. All the removed peer deps are already listed in devDeps which they seem to belong to.

## Related Issues

Fixes #613.

## Summary



## Check List

- [ ] `yarn run prettier` for formatting code and docs
