### PR TITLE
fix(readme): add note about shallow proxy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -272,7 +272,7 @@ subscribe(state, () => {
 
 While the separation of proxy state and its snapshot is important,
 it's confusing for beginners.
-We have a convenient util to improve developer experience.
+We have a convenient util to improve developer experience. useProxy returns shallow proxy state and its snapshot, meaning you can only mutate on root level.
 
 ```js
 import { useProxy } from 'valtio/utils'


### PR DESCRIPTION
## Related Issues

Related to #620.

## Summary

Adds note to useProxy readme about its shallow proxy implementation and that you can only mutate on the root level.

## Check List

- [x] `yarn run prettier` for formatting code and docs
