### PR TITLE
feat: Cache class getter calls.

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -107,23 +107,50 @@ const buildProxyFunction = (
       : Object.create(Object.getPrototypeOf(target))
     markToTrack(snap, true) // mark to track
     snapCache.set(target, [version, snap])
-    Reflect.ownKeys(target).forEach((key) => {
+
+    function getValue(key: PropertyKey): any {
       const value = Reflect.get(target, key)
       if (refSet.has(value as object)) {
         markToTrack(value as object, false) // mark not to track
-        snap[key] = value
-      } else if (value instanceof Promise) {
+        return value
+      } else if (proxyStateMap.has(value as object)) {
+        return snapshot(value as object, handlePromise)
+      } else {
+        return value
+      }
+    }
+
+    // This will copy all object getters, functions, and values
+    Reflect.ownKeys(target).forEach((key) => {
+      const value = getValue(key)
+      if (value instanceof Promise) {
         Object.defineProperty(snap, key, {
           get() {
             return handlePromise(value)
           },
         })
-      } else if (proxyStateMap.has(value as object)) {
-        snap[key] = snapshot(value as object, handlePromise)
       } else {
         snap[key] = value
       }
     })
+
+    // Now look for proto getters to essentially cache them
+    const protoGetters = findPrototypeGetters(target)
+    protoGetters.forEach((key) => {
+      const value = getValue(key)
+      if (value instanceof Promise) {
+        Object.defineProperty(snap, key, {
+          get() {
+            return handlePromise(value)
+          },
+        })
+      } else {
+        // We have to use `defineProperty` instead of `snap[key] = value` to explicitly
+        // set the value on the snap instance itself, and not just invoke the setter
+        Object.defineProperty(snap, key, { value })
+      }
+    })
+
     return Object.freeze(snap)
   },
 
@@ -379,3 +406,18 @@ export function ref<T extends object>(obj: T): T & AsRef {
 }
 
 export const unstable_buildProxyFunction = buildProxyFunction
+
+/** Walks the prototype chain looking for getters. */
+function findPrototypeGetters(target: any): PropertyKey[] {
+  const protoGetters: PropertyKey[] = []
+  let current = Object.getPrototypeOf(target)
+  while (current && current !== Object.prototype) {
+    protoGetters.push(
+      ...Reflect.ownKeys(current).filter(
+        (key) => Object.getOwnPropertyDescriptor(current, key)?.get
+      )
+    )
+    current = Object.getPrototypeOf(current)
+  }
+  return protoGetters
+}

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -411,7 +411,11 @@ export const unstable_buildProxyFunction = buildProxyFunction
 function findPrototypeGetters(target: any): PropertyKey[] {
   const protoGetters: PropertyKey[] = []
   let current = Object.getPrototypeOf(target)
-  while (current && current !== Object.prototype) {
+  while (
+    current &&
+    current !== Object.prototype &&
+    current !== Array.prototype
+  ) {
     protoGetters.push(
       ...Reflect.ownKeys(current).filter(
         (key) => Object.getOwnPropertyDescriptor(current, key)?.get


### PR DESCRIPTION
## Summary

This makes the behavior the same as object getters, which I believe is both:

- desirable in general (caching class getters as a feature)
- reduces the complexity for users of having some getters work one way, and others work another; this is a more consistent mental model that "snapshots always cache getters".

## Check List

- [x] `yarn run prettier` for formatting code and docs
