### PR TITLE
fix(build): reorder the types field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,20 +18,20 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./index.d.ts",
       "import": {
         "types": "./esm/index.d.mts",
         "default": "./esm/index.mjs"
       },
-      "types": "./index.d.ts",
       "module": "./esm/index.js",
       "default": "./index.js"
     },
     "./*": {
+      "types": "./*.d.ts",
       "import": {
         "types": "./esm/*.d.mts",
         "default": "./esm/*.mjs"
       },
-      "types": "./*.d.ts",
       "module": "./esm/*.js",
       "default": "./*.js"
     }


### PR DESCRIPTION
## Summary
According to the typescript documentation: `Entry-point` for TypeScript resolution must occur first!

>Reference:  
> https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

## Check List

- [ √ ] `yarn run prettier` for formatting code and docs
