### PR TITLE
fix(vanilla): proxy can be created from snapshot

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -299,14 +299,14 @@ const buildProxyFunction = (
         initialObject,
         key
       ) as PropertyDescriptor
-      const hasValue = 'value' in desc
-      // `delete desc.value` is required, because otherwise
-      // we can't set a new value in the `if (hasValue)` block below.
-      delete desc.value
-      Object.defineProperty(baseObject, key, desc)
-      if (hasValue) {
+      if ('value' in desc) {
         proxyObject[key as keyof T] = initialObject[key as keyof T]
+        // We need to delete desc.value because we already set it,
+        // and delete desc.writable because we want to write it again.
+        delete desc.value
+        delete desc.writable
       }
+      Object.defineProperty(baseObject, key, desc)
     })
     return proxyObject
   }

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -42,3 +42,10 @@ it('should not change snapshot with assigning same object', async () => {
   const snap2 = snapshot(state)
   expect(snap1).toBe(snap2)
 })
+
+it('should create a new proxy from a snapshot', async () => {
+  const state = proxy({ c: 0 })
+  const snap1 = snapshot(state)
+  const state2 = proxy(snap1)
+  expect(state2.c).toBe(0)
+})


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #670 

## Summary

#654 broke one use case described in #670. (tbh, this isn't intended use case).
When copying from an initial object to a proxy base object, we should make it writable to make the proxy object mutable.

## Check List

- [x] `yarn run prettier` for formatting code and docs
