### PR TITLE
feat: Add isStore.

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -33,6 +33,8 @@ type Snapshot<T> = T extends AnyFunction
  */
 export type INTERNAL_Snapshot<T> = Snapshot<T>
 
+const IS_STORE_SYMBOL = Symbol()
+
 type HandlePromise = <P extends Promise<any>>(promise: P) => Awaited<P>
 
 type CreateSnapshot = <T extends object>(
@@ -242,6 +244,12 @@ const buildProxyFunction = (
         }
         return deleted
       },
+      get(target, prop, receiver) {
+        if (prop === IS_STORE_SYMBOL) {
+          return true
+        }
+        return Reflect.get(target, prop, receiver)
+      },
       set(target: T, prop: string | symbol, value: any, receiver: object) {
         const hasPrevValue = Reflect.has(target, prop)
         const prevValue = Reflect.get(target, prop, receiver)
@@ -390,6 +398,10 @@ export function snapshot<T extends object>(
 export function ref<T extends object>(obj: T): T & AsRef {
   refSet.add(obj)
   return obj as T & AsRef
+}
+
+export function isStore(obj: any): obj is object {
+  return typeof obj === 'object' && (obj as any)[IS_STORE_SYMBOL] === true
 }
 
 export const unstable_buildProxyFunction = buildProxyFunction


### PR DESCRIPTION
## Related Issues or Discussions

Related to my `useStore` prototypes (https://github.com/pmndrs/valtio/discussions/662)

## Summary

When working generically with a store, and wanting to handle it recursively, it's useful to ask "is this nested value itself a store?".

Currently this is not necessary for Valtio & proxy-compare, b/c `createSnapshot` _pushes_ "this is special"-ness into proxy-compare's `markToTrack`, but 3rd party libraries/hooks like `useStore` don't have that blessed push-based mechanism, so need a pull-/probed-based mechanism to detect store-ness/special-ness.

Very open to alternative approaches/impls that accomplish the "is this a store?" goal.

## Check List

- [x] `yarn run prettier` for formatting code and docs
