### PR TITLE
Allow passthrough of Redux devtools options

### DIFF
--- a/src/vanilla/utils/devtools.ts
+++ b/src/vanilla/utils/devtools.ts
@@ -1,5 +1,5 @@
 import { snapshot, subscribe } from '../../vanilla.ts'
-import type {} from '@redux-devtools/extension'
+import type { EnhancerOptions } from '@redux-devtools/extension'
 
 // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
 type Message = {
@@ -10,9 +10,8 @@ type Message = {
 
 const DEVTOOLS = Symbol()
 
-type Options = {
+type Options = EnhancerOptions & {
   enabled?: boolean
-  name?: string
 }
 
 export function devtools<T extends object>(
@@ -67,7 +66,7 @@ export function devtools<T extends object>(
   }
 
   let isTimeTraveling = false
-  const devtools = extension.connect({ name })
+  const devtools = extension.connect({ name, ...options })
   const unsub1 = subscribe(proxyObject, (ops) => {
     const action = ops
       .filter(([_, path]) => path[0] !== DEVTOOLS)

--- a/src/vanilla/utils/devtools.ts
+++ b/src/vanilla/utils/devtools.ts
@@ -1,5 +1,5 @@
-import { snapshot, subscribe } from '../../vanilla.ts'
 import type { EnhancerOptions } from '@redux-devtools/extension'
+import { snapshot, subscribe } from '../../vanilla.ts'
 
 // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
 type Message = {

--- a/src/vanilla/utils/devtools.ts
+++ b/src/vanilla/utils/devtools.ts
@@ -1,5 +1,5 @@
-import type { EnhancerOptions } from '@redux-devtools/extension'
 import { snapshot, subscribe } from '../../vanilla.ts'
+import type {} from '@redux-devtools/extension'
 
 // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
 type Message = {
@@ -10,9 +10,14 @@ type Message = {
 
 const DEVTOOLS = Symbol()
 
-type Options = EnhancerOptions & {
+type EnhancerOptions = Parameters<
+  NonNullable<(typeof window)['__REDUX_DEVTOOLS_EXTENSION__']>['connect']
+>[0]
+
+type Options = {
   enabled?: boolean
-}
+  name?: string
+} & EnhancerOptions
 
 export function devtools<T extends object>(
   proxyObject: T,
@@ -48,7 +53,7 @@ export function devtools<T extends object>(
     )
     options = { name: options }
   }
-  const { enabled, name = '' } = options || {}
+  const { enabled, name = '', ...rest } = options || {}
 
   let extension: (typeof window)['__REDUX_DEVTOOLS_EXTENSION__'] | false
   try {
@@ -66,7 +71,7 @@ export function devtools<T extends object>(
   }
 
   let isTimeTraveling = false
-  const devtools = extension.connect({ name, ...options })
+  const devtools = extension.connect({ name, ...rest })
   const unsub1 = subscribe(proxyObject, (ops) => {
     const action = ops
       .filter(([_, path]) => path[0] !== DEVTOOLS)


### PR DESCRIPTION
The current 'devtools()' util in Valtio restricts the Redux-devtools option to the 'name' field, and a custom 'enabled' field. But it might be useful to pass other devtools options too to Redux-devtools. My current case, which motivated this, is that I'm having a large data set in the proxy store (as a ref() of course), and any change to the proxy causes a significant lag in redux-devtools. This has been performance measured in Chrome. The solution is to customize redux-devtools' serializer to skip the large data part, as I don't need to see that part. This way I can further debug other perf-related bottlenecks in my heavy app. During this effort, it seemed like Valtio unnecessarily restricted the redux-devtools options object, so this change only lifts this restriction.

## Related Issues or Discussions

Fixes #

## Summary



## Check List

- [ ] `yarn run prettier` for formatting code and docs
