### PR TITLE
fix: invalidate snap cache when property is removed from object

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -244,6 +244,7 @@ const buildProxyFunction = (
     const handler: ProxyHandler<T> = {
       deleteProperty(target: T, prop: string | symbol) {
         const prevValue = Reflect.get(target, prop)
+        snapCache.delete(target as Object)
         removePropListener(prop)
         const deleted = Reflect.deleteProperty(target, prop)
         if (deleted) {

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -244,7 +244,6 @@ const buildProxyFunction = (
     const handler: ProxyHandler<T> = {
       deleteProperty(target: T, prop: string | symbol) {
         const prevValue = Reflect.get(target, prop)
-        snapCache.delete(target as Object)
         removePropListener(prop)
         const deleted = Reflect.deleteProperty(target, prop)
         if (deleted) {

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -77,10 +77,10 @@ it('should create a new proxy from a snapshot', async () => {
 it('should return updated property snapshot when property is updated after removed from Array and added to array again', async () => {
   /**
    * error occurs when
-   * [1]. Remove target item should be in array
+   * [1]. Remove target item should be in the array
    * [2]. Remove target item should be nested object
-   * [3]. Array should subscribed
-   * [4]. Array should pass to snapshot() before target item removed
+   * [3]. The array should be subscribed
+   * [4]. The array should pass to snapshot() before the target item removed
    */
 
   const array = proxy([


### PR DESCRIPTION
## Related Issues or Discussions

related to  
https://github.com/pmndrs/valtio/issues/712


Just like that change [1], I suggest removing snap cache when props are removed from the parent object or array

[1] [This change](https://github.com/pmndrs/valtio/pull/599/files) is removing the listeners for removed props from the parent object or array.

FYI: #712 is an issue that has occurred since version 1.8.0  caused by https://github.com/pmndrs/valtio/commit/ec445576274f6b1c53c86099846592b5550e24fd or https://github.com/pmndrs/valtio/pull/599

Fixes #712

## Summary
 Adding remove snap cache logic to `deleteProperty` function


## Check List

- [ ] `yarn run prettier` for formatting code and docs
