### PR TITLE
fix(vanilla): Snapshot<T> ignores branded primitive types

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -17,6 +17,8 @@ type Op =
   | [op: 'reject', path: Path, error: unknown]
 type Listener = (op: Op, nextVersion: number) => void
 
+type Primitive = string | number | boolean | null | undefined | symbol | bigint
+
 type SnapshotIgnore =
   | Date
   | Map<any, any>
@@ -27,6 +29,7 @@ type SnapshotIgnore =
   | Error
   | RegExp
   | AnyFunction
+  | Primitive
 
 type Snapshot<T> = T extends SnapshotIgnore
   ? T

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -202,4 +202,20 @@ describe('snapsoht typings', () => {
       >
     >(true)
   })
+
+  it('ignores primitive types that have been branded/tagged', () => {
+    const symbolTag = Symbol()
+    expectType<
+      TypeEqual<
+        Snapshot<{
+          brandedWithStringKey: string & { __brand: 'Brand' }
+          brandedWithSymbolKey: number & { [symbolTag]: 'Tag' }
+        }>,
+        {
+          readonly brandedWithStringKey: string & { __brand: 'Brand' }
+          readonly brandedWithSymbolKey: number & { [symbolTag]: 'Tag' }
+        }
+      >
+    >(true)
+  })
 })

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -146,7 +146,7 @@ describe('snapsoht typings', () => {
     >(true)
   })
 
-  it('convets object properties to readonly recursively', () => {
+  it('converts object properties to readonly recursively', () => {
     expectType<
       TypeEqual<
         Snapshot<{


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #747

## Summary

Add the 7 primitive types (`string`, `number`, `boolean`, `undefined`, `null`, `symbol`, `bigint`) to `SnapshotIgnore`, so any subtypes of these primitive types are ignored by `Snapshot<T>`.

This fixes a bug where branded/tagged primitive types (usually created by intersecting them with a faux object type) are incorrectly transformed when passed through `Snapshot<T>`.

This doesn't handle object-like branded/tagged types, but such types are less common in practice.

## Check List

- [x] `yarn run prettier` for formatting code and docs
