### PR TITLE
fix(vanilla): Prevent adding new property on snapshot

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -146,6 +146,7 @@ const buildProxyFunction = (
       }
       Object.defineProperty(snap, key, desc)
     })
+    Object.preventExtensions(snap)
     return snap
   },
 

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -146,8 +146,7 @@ const buildProxyFunction = (
       }
       Object.defineProperty(snap, key, desc)
     })
-    Object.preventExtensions(snap)
-    return snap
+    return Object.preventExtensions(snap)
   },
 
   proxyCache = new WeakMap<object, ProxyObject>(),

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -1,7 +1,7 @@
 import { createProxy, getUntracked } from 'proxy-compare'
 import { TypeEqual, expectType } from 'ts-expect'
-import { INTERNAL_Snapshot as Snapshot, proxy, snapshot } from 'valtio'
 import { describe, expect, it } from 'vitest'
+import { INTERNAL_Snapshot as Snapshot, proxy, snapshot } from 'valtio'
 
 const sleep = (ms: number) =>
   new Promise((resolve) => {

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -1,7 +1,7 @@
 import { createProxy, getUntracked } from 'proxy-compare'
 import { TypeEqual, expectType } from 'ts-expect'
-import { describe, expect, it } from 'vitest'
 import { INTERNAL_Snapshot as Snapshot, proxy, snapshot } from 'valtio'
+import { describe, expect, it } from 'vitest'
 
 const sleep = (ms: number) =>
   new Promise((resolve) => {
@@ -43,6 +43,26 @@ it('should not change snapshot with assigning same object', async () => {
   state.obj = obj
   const snap2 = snapshot(state)
   expect(snap1).toBe(snap2)
+})
+
+it('should make the snapshot immutable', () => {
+  const state = proxy<{ foo: number; bar?: string }>({ foo: 1 })
+  const snap = snapshot(state)
+
+  // Overwriting existing property
+  expect(() => {
+    ;(snap as typeof state).foo = 100
+  }).toThrow()
+
+  // Extension (adding new property)
+  expect(() => {
+    ;(snap as typeof state).bar = 'hello'
+  }).toThrow()
+
+  // Note: The current implementation does not prevent property removal.
+  // Do not add a test for this unless we come up with an implementation that
+  // supports it.
+  // See https://github.com/pmndrs/valtio/issues/749
 })
 
 it('should not cause proxy-compare to copy', async () => {


### PR DESCRIPTION
## Related Issues or Discussions

Partially deals with #749 by disallowing property addition
(but does not completely fix it, since we still allow property removal)

## Summary

As a performance optimization, we currently mark [properties of snapshots as configurable](https://github.com/pmndrs/valtio/blob/5d0eca7edc25aa7f17fb8082ef14244a35fc12b2/src/vanilla.ts#L128C10-L130). This allows users to inadvertently add or remove properties on a snapshot object with no warning. Although TypeScript typings do prevent this to a degree, it is not foolproof.

While we currently do not have a robust solution that disallows property removal while maintaining the current level performance, we can prevent addition of new properties on the snapshot by calling `Object.preventExtensions()` on it.

## Check List

- [x] `yarn run prettier` for formatting code and docs
