### PR TITLE
feat(vanilla): Support class fields (defineProperty)

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -318,7 +318,7 @@ const buildProxyFunction = (
           const prevDesc = Reflect.getOwnPropertyDescriptor(target, prop)
           if (!prevDesc || shouldTrapDefineProperty(prevDesc)) {
             trapSet(
-              !!prevDesc,
+              !!prevDesc && 'value' in prevDesc,
               prevDesc?.value,
               prop,
               desc.value,

--- a/tests/class.test.tsx
+++ b/tests/class.test.tsx
@@ -355,3 +355,31 @@ it('no extra re-renders with getters', async () => {
     getByText('sum: 2 (2)')
   })
 })
+
+it('support class fields (defineProperty semantics)', async () => {
+  class Base {
+    constructor() {
+      return proxy(this)
+    }
+  }
+  class CountClass extends Base {
+    counter = { count: 0 }
+  }
+  const obj = new CountClass()
+
+  const Counter = () => {
+    const snap = useSnapshot(obj)
+    return <div>count: {snap.counter.count}</div>
+  }
+
+  const { findByText } = render(
+    <StrictMode>
+      <Counter />
+    </StrictMode>
+  )
+
+  await findByText('count: 0')
+
+  obj.counter.count = 1
+  await findByText('count: 1')
+})


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #759 (the feature request at the end)

## Summary

Adds support for ES2022 class fields created with `Object.defineProperty()` semantics. When a configurable, enumerable, and writable (CEW) own property (usually a class field) is created on a proxy object that does not have the property, or has a CEW own property of the same name, treat it like a [[set]] trap.

## Check List

- [x] `yarn run prettier` for formatting code and docs
