### PR TITLE
Revert "feat(vanilla): Support class fields (defineProperty) (#760)"

### DIFF
--- a/tests/class.test.tsx
+++ b/tests/class.test.tsx
@@ -355,31 +355,3 @@ it('no extra re-renders with getters', async () => {
     getByText('sum: 2 (2)')
   })
 })
-
-it('support class fields (defineProperty semantics)', async () => {
-  class Base {
-    constructor() {
-      return proxy(this)
-    }
-  }
-  class CountClass extends Base {
-    counter = { count: 0 }
-  }
-  const obj = new CountClass()
-
-  const Counter = () => {
-    const snap = useSnapshot(obj)
-    return <div>count: {snap.counter.count}</div>
-  }
-
-  const { findByText } = render(
-    <StrictMode>
-      <Counter />
-    </StrictMode>
-  )
-
-  await findByText('count: 0')
-
-  obj.counter.count = 1
-  await findByText('count: 1')
-})


### PR DESCRIPTION
This reverts commit c0bda5afd2780fb929656a87bcc9e16bcf189fd8.

Due to [what I presume is a bug in the Hermes engine](https://github.com/facebook/hermes/issues/1065), React Native projects cannot use Valtio 1.11.0. Let's revert #760 to support existing React Native users.

## Related Issues or Discussions

Fixes #765
May fix #764 (but we need confirmation from actual RN users)

## Summary

This reverts #760 (c0bda5afd2780fb929656a87bcc9e16bcf189fd8). The following pattern (described in detail at #759) is no longer explicitly supported:

```js
class ValtioProxy {
  constructor() {
    return proxy(this)
  }
}

class MyStore extends ValtioProxy {
  field1 = 'asdf' // OK
  field2 = []     // This works in v1.11.0.
                  // But when this PR is merged,
                  // the array will no longer be reactive
}

const store = new MyStore()
store.field2.push(1) // Will re-render views in v1.11.0
                     // but not after this PR is merged
```

To work around this, we can explicitly set the field in the constructor, which properly invokes the `set` proxy trap:

```js
class MyStore extends ValtioProxy {
  constructor() {
    super()
    this.field2 = [] // This will be reactive
  }
}
```

Alternatively, you can configure your transpiler to use 'set' semantics for class fields (e.g. [`useDefineForClassFields: false`](https://www.typescriptlang.org/tsconfig#useDefineForClassFields). (Personally I advise against this, because it deviates from the modern ECMAScript spec)

## Check List

- [x] `yarn run prettier` for formatting code and docs
