### PR TITLE
fix: declare @types/react as peerDep to avoid phantom dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,9 +157,13 @@
     "vitest": "^0.33.0"
   },
   "peerDependencies": {
+    "@types/react": ">=16.8",
     "react": ">=16.8"
   },
   "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
     "react": {
       "optional": true
     }


### PR DESCRIPTION
## Related Issues or Discussions

Fixes [#2047 of jotai](https://github.com/pmndrs/jotai/issues/2047)

## Summary



## Check List

- [ ] `yarn run prettier` for formatting code and docs
