### PR TITLE
fix(utils): improve devtools typing to avoid depending on @redux-devtools/extension

### DIFF
--- a/docs/api/utils/devtools.mdx
+++ b/docs/api/utils/devtools.mdx
@@ -44,7 +44,7 @@ subscribe(state, () => {
 
 #### Use it with TypeScript
 
-It's recommended to install and import types from`@redux-devtools/extension` to get types correctly.
+It's recommended to install and import types from `@redux-devtools/extension` to get types correctly.
 
 ```ts
 import type {} from '@redux-devtools/extension'

--- a/docs/api/utils/devtools.mdx
+++ b/docs/api/utils/devtools.mdx
@@ -41,3 +41,12 @@ subscribe(state, () => {
   const obj = snapshot(state) // A snapshot is an immutable object
 })
 ````
+
+#### Use it with TypeScript
+
+It's recommended to install and import types from`@redux-devtools/extension` to get types correctly.
+
+```ts
+import type {} from '@redux-devtools/extension'
+import { devtools } from 'valtio/utils'
+```

--- a/src/vanilla/utils/devtools.ts
+++ b/src/vanilla/utils/devtools.ts
@@ -1,76 +1,6 @@
 import { snapshot, subscribe } from '../../vanilla.ts'
 import type {} from '@redux-devtools/extension'
 
-// Copy types to avoid import type { Config } from '@redux-devtools/extension'
-// https://github.com/pmndrs/valtio/issues/776
-type Action<T = any> = {
-  type: T
-}
-type ActionCreator<A, P extends any[] = any[]> = {
-  (...args: P): A
-}
-type EnhancerOptions = {
-  name?: string
-  actionCreators?:
-    | ActionCreator<any>[]
-    | {
-        [key: string]: ActionCreator<any>
-      }
-  latency?: number
-  maxAge?: number
-  serialize?:
-    | boolean
-    | {
-        options?:
-          | undefined
-          | boolean
-          | {
-              date?: true
-              regex?: true
-              undefined?: true
-              error?: true
-              symbol?: true
-              map?: true
-              set?: true
-              function?: true | ((fn: (...args: any[]) => any) => string)
-            }
-        replacer?: (key: string, value: unknown) => any
-        reviver?: (key: string, value: unknown) => any
-        immutable?: any
-        refs?: any
-      }
-  actionSanitizer?: <A extends Action>(action: A, id: number) => A
-  stateSanitizer?: <S>(state: S, index: number) => S
-  actionsBlacklist?: string | string[]
-  actionsWhitelist?: string | string[]
-  actionsDenylist?: string | string[]
-  actionsAllowlist?: string | string[]
-  predicate?: <S, A extends Action>(state: S, action: A) => boolean
-  shouldRecordChanges?: boolean
-  pauseActionType?: string
-  autoPause?: boolean
-  shouldStartLocked?: boolean
-  shouldHotReload?: boolean
-  shouldCatchErrors?: boolean
-  features?: {
-    pause?: boolean
-    lock?: boolean
-    persist?: boolean
-    export?: boolean | 'custom'
-    import?: boolean | 'custom'
-    jump?: boolean
-    skip?: boolean
-    reorder?: boolean
-    dispatch?: boolean
-    test?: boolean
-  }
-  trace?: boolean | (<A extends Action>(action: A) => string)
-  traceLimit?: number
-}
-type Config = EnhancerOptions & {
-  type?: string
-}
-
 // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
 type Message = {
   type: string
@@ -79,6 +9,12 @@ type Message = {
 }
 
 const DEVTOOLS = Symbol()
+
+type Config = Parameters<
+  (Window extends { __REDUX_DEVTOOLS_EXTENSION__?: infer T }
+    ? T
+    : any)['connect']
+>[0]
 
 type Options = {
   enabled?: boolean

--- a/src/vanilla/utils/devtools.ts
+++ b/src/vanilla/utils/devtools.ts
@@ -1,6 +1,76 @@
 import { snapshot, subscribe } from '../../vanilla.ts'
 import type {} from '@redux-devtools/extension'
 
+// Copy types to avoid import type { Config } from '@redux-devtools/extension'
+// https://github.com/pmndrs/valtio/issues/776
+type Action<T = any> = {
+  type: T
+}
+type ActionCreator<A, P extends any[] = any[]> = {
+  (...args: P): A
+}
+type EnhancerOptions = {
+  name?: string
+  actionCreators?:
+    | ActionCreator<any>[]
+    | {
+        [key: string]: ActionCreator<any>
+      }
+  latency?: number
+  maxAge?: number
+  serialize?:
+    | boolean
+    | {
+        options?:
+          | undefined
+          | boolean
+          | {
+              date?: true
+              regex?: true
+              undefined?: true
+              error?: true
+              symbol?: true
+              map?: true
+              set?: true
+              function?: true | ((fn: (...args: any[]) => any) => string)
+            }
+        replacer?: (key: string, value: unknown) => any
+        reviver?: (key: string, value: unknown) => any
+        immutable?: any
+        refs?: any
+      }
+  actionSanitizer?: <A extends Action>(action: A, id: number) => A
+  stateSanitizer?: <S>(state: S, index: number) => S
+  actionsBlacklist?: string | string[]
+  actionsWhitelist?: string | string[]
+  actionsDenylist?: string | string[]
+  actionsAllowlist?: string | string[]
+  predicate?: <S, A extends Action>(state: S, action: A) => boolean
+  shouldRecordChanges?: boolean
+  pauseActionType?: string
+  autoPause?: boolean
+  shouldStartLocked?: boolean
+  shouldHotReload?: boolean
+  shouldCatchErrors?: boolean
+  features?: {
+    pause?: boolean
+    lock?: boolean
+    persist?: boolean
+    export?: boolean | 'custom'
+    import?: boolean | 'custom'
+    jump?: boolean
+    skip?: boolean
+    reorder?: boolean
+    dispatch?: boolean
+    test?: boolean
+  }
+  trace?: boolean | (<A extends Action>(action: A) => string)
+  traceLimit?: number
+}
+type Config = EnhancerOptions & {
+  type?: string
+}
+
 // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
 type Message = {
   type: string
@@ -10,14 +80,10 @@ type Message = {
 
 const DEVTOOLS = Symbol()
 
-type EnhancerOptions = Parameters<
-  NonNullable<(typeof window)['__REDUX_DEVTOOLS_EXTENSION__']>['connect']
->[0]
-
 type Options = {
   enabled?: boolean
   name?: string
-} & EnhancerOptions
+} & Config
 
 export function devtools<T extends object>(
   proxyObject: T,


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #776

## Summary

I found the same issue in zustand(https://github.com/pmndrs/zustand/issues/1205#issuecomment-1221270524), so I added the same workaround(copied the type defs from `@redux-devtools/extension`)
I'm not sure if this way is a desired way, but I did it anyway..

## Check List

- [x] `yarn run prettier` for formatting code and docs
