### PR TITLE
(docs) Added bunshi as an alternative and working example

### DIFF
--- a/docs/guides/component-state.mdx
+++ b/docs/guides/component-state.mdx
@@ -30,9 +30,17 @@ const MyCounter = () => {
 }
 ```
 
-If you are not happy with useRef usage, consider [use-constant](https://www.npmjs.com/package/use-constant) instead.
-You may also create custom hooks wrapping useContext and optionally useSnapshot.
-
 ## Codesandbox example
 
 https://codesandbox.io/s/valtio-component-ye5tbg?file=/src/App.tsx
+
+## Alternatives
+
+If you are not happy with useRef usage, consider:
+ * [use-constant](https://www.npmjs.com/package/use-constant)
+ * [bunshi](https://www.bunshi.org/recipes/valtio/)
+ * You may also create custom hooks wrapping useContext and optionally useSnapshot.
+
+### Bunshi example
+
+https://codesandbox.io/s/77r53c?file=/molecules.ts

--- a/docs/guides/component-state.mdx
+++ b/docs/guides/component-state.mdx
@@ -37,9 +37,10 @@ https://codesandbox.io/s/valtio-component-ye5tbg?file=/src/App.tsx
 ## Alternatives
 
 If you are not happy with useRef usage, consider:
- * [use-constant](https://www.npmjs.com/package/use-constant)
- * [bunshi](https://www.bunshi.org/recipes/valtio/)
- * You may also create custom hooks wrapping useContext and optionally useSnapshot.
+
+- [use-constant](https://www.npmjs.com/package/use-constant)
+- [bunshi](https://www.bunshi.org/recipes/valtio/)
+- You may also create custom hooks wrapping useContext and optionally useSnapshot.
 
 ### Bunshi example
 

--- a/docs/how-tos/how-to-use-with-context.mdx
+++ b/docs/how-tos/how-to-use-with-context.mdx
@@ -33,9 +33,10 @@ const MyCounter = () => {
 ## Alternatives
 
 If you are not happy with `useRef` usage, consider:
- * [use-constant](https://www.npmjs.com/package/use-constant)
- * [bunshi](https://www.bunshi.org/recipes/valtio/)
- * You can create custom hooks to `useContext` and optionally `useSnapshot`
+
+- [use-constant](https://www.npmjs.com/package/use-constant)
+- [bunshi](https://www.bunshi.org/recipes/valtio/)
+- You can create custom hooks to `useContext` and optionally `useSnapshot`
 
 ### Bunshi example
 

--- a/docs/how-tos/how-to-use-with-context.mdx
+++ b/docs/how-tos/how-to-use-with-context.mdx
@@ -30,5 +30,13 @@ const MyCounter = () => {
 }
 ```
 
-- If you are not happy with `useRef` usage, consider [use-constant](https://www.npmjs.com/package/use-constant) instead.
-- You can create custom hooks to `useContext` and optionally `useSnapshot`.
+## Alternatives
+
+If you are not happy with `useRef` usage, consider:
+ * [use-constant](https://www.npmjs.com/package/use-constant)
+ * [bunshi](https://www.bunshi.org/recipes/valtio/)
+ * You can create custom hooks to `useContext` and optionally `useSnapshot`
+
+### Bunshi example
+
+https://codesandbox.io/s/77r53c?file=/molecules.ts


### PR DESCRIPTION
## Summary

Adds bunshi as an alternative to `useRef` and `useConstant`, linked to docs on the bunshi website, and included a working sandbox example.

## Check List

- [x] `yarn run prettier` for formatting code and docs
