### PR TITLE
fix(utils): useProxy to avoid re-renders when no props are touched

### DIFF
--- a/src/react/utils/useProxy.ts
+++ b/src/react/utils/useProxy.ts
@@ -1,6 +1,8 @@
 import { useLayoutEffect } from 'react'
 import { useSnapshot } from '../../react.ts'
 
+const DUMMY_SYMBOL = Symbol()
+
 /**
  * useProxy
  *
@@ -28,8 +30,10 @@ export function useProxy<T extends object>(
 ): T {
   const snapshot = useSnapshot(proxy, options) as T
 
-  let isRendering = true
+  // touch dummy prop so that it doesn't trigger re-renders when no props are touched.
+  ;(snapshot as any)[DUMMY_SYMBOL]
 
+  let isRendering = true
   useLayoutEffect(() => {
     // This is an intentional hack
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Related Issues or Discussions

Fixes https://github.com/pmndrs/valtio/discussions/808#discussioncomment-7476506

## Summary

Touch a dummy prop so that it avoids re-renders if no other props are touched.
I'm not sure if we should add this hack, or just add a caveat note in docs.

## Check List

- [x] `yarn run prettier` for formatting code and docs
