### PR TITLE
refactor: revisit prettier config to be minimal

### DIFF
--- a/docs/api/advanced/subscribe.mdx
+++ b/docs/api/advanced/subscribe.mdx
@@ -18,7 +18,7 @@ const state = proxy({ count: 0 })
 
 // Subscribe to all changes to the state proxy (and its child proxies)
 const unsubscribe = subscribe(state, () =>
-  console.log('state has changed to', state)
+  console.log('state has changed to', state),
 )
 // Unsubscribe by calling the result
 unsubscribe()

--- a/docs/api/basic/useSnapshot.mdx
+++ b/docs/api/basic/useSnapshot.mdx
@@ -33,7 +33,8 @@ function Counter() {
           if (state.count < 10) {
             ++state.count
           }
-        }}>
+        }}
+      >
         +1
       </button>
     </div>

--- a/docs/api/utils/derive.mdx
+++ b/docs/api/utils/derive.mdx
@@ -37,7 +37,7 @@ derive(
   },
   {
     proxy: state,
-  }
+  },
 )
 ```
 

--- a/docs/api/utils/subscribeKey.mdx
+++ b/docs/api/utils/subscribeKey.mdx
@@ -14,7 +14,7 @@ import { subscribeKey } from 'valtio/utils'
 
 const state = proxy({ count: 0, text: 'hello' })
 subscribeKey(state, 'count', (v) =>
-  console.log('state.count has changed to', v)
+  console.log('state.count has changed to', v),
 )
 ```
 

--- a/docs/how-tos/how-to-avoid-rerenders-manually.mdx
+++ b/docs/how-tos/how-to-avoid-rerenders-manually.mdx
@@ -39,7 +39,7 @@ const Component = () => {
           setCount(state.count)
         }
       }),
-    []
+    [],
   )
   return <>{count}</>
 }

--- a/docs/how-tos/how-to-persist-states.mdx
+++ b/docs/how-tos/how-to-persist-states.mdx
@@ -13,7 +13,7 @@ const state = proxy(
   JSON.parse(localStorage.getItem('foo')) || {
     count: 0,
     text: 'hello',
-  }
+  },
 )
 
 subscribe(state, () => {

--- a/docs/how-tos/some-gotchas.mdx
+++ b/docs/how-tos/some-gotchas.mdx
@@ -76,7 +76,7 @@ const ChildComponent = React.memo(
     <div>
       {title} - {description}
     </div>
-  )
+  ),
 )
 
 const ParentComponent = () => {

--- a/package.json
+++ b/package.json
@@ -81,11 +81,7 @@
   },
   "prettier": {
     "semi": false,
-    "trailingComma": "es5",
-    "singleQuote": true,
-    "bracketSameLine": true,
-    "tabWidth": 2,
-    "printWidth": 80
+    "singleQuote": true
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ import { subscribe } from 'valtio'
 
 // Subscribe to all state changes
 const unsubscribe = subscribe(state, () =>
-  console.log('state has changed to', state)
+  console.log('state has changed to', state),
 )
 // Unsubscribe by calling the result
 unsubscribe()
@@ -146,7 +146,7 @@ import { subscribeKey } from 'valtio/utils'
 
 const state = proxy({ count: 0, text: 'hello' })
 subscribeKey(state, 'count', (v) =>
-  console.log('state.count has changed to', v)
+  console.log('state.count has changed to', v),
 )
 ```
 

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -17,7 +17,7 @@ const macro = ({ references }: any) => {
     path.parentPath?.parentPath?.replaceWith(
       t.variableDeclaration('const', [
         t.variableDeclarator(snap, t.callExpression(hook, [proxy])),
-      ])
+      ]),
     )
     let inFunction = 0
     path.parentPath?.getFunctionParent()?.traverse({

--- a/src/macro/vite.ts
+++ b/src/macro/vite.ts
@@ -26,7 +26,7 @@ export const valtioMacro = defineMacro(`useProxy`)
     path.parentPath?.replaceWith(
       t.variableDeclaration('const', [
         t.variableDeclarator(snap, t.callExpression(hook, [proxy])),
-      ])
+      ]),
     )
 
     let inFunction = 0

--- a/src/react.ts
+++ b/src/react.ts
@@ -26,7 +26,7 @@ const { useSyncExternalStore } = useSyncExternalStoreExports
 
 const useAffectedDebugValue = (
   state: object,
-  affected: WeakMap<object, unknown>
+  affected: WeakMap<object, unknown>,
 ) => {
   const pathList = useRef<(string | number | symbol)[][]>()
   useEffect(() => {
@@ -117,7 +117,7 @@ type Options = {
  */
 export function useSnapshot<T extends object>(
   proxyObject: T,
-  options?: Options
+  options?: Options,
 ): Snapshot<T> {
   const notifyInSync = options?.sync
   const lastSnapshot = useRef<Snapshot<T>>()
@@ -130,7 +130,7 @@ export function useSnapshot<T extends object>(
         callback() // Note: do we really need this?
         return unsub
       },
-      [proxyObject, notifyInSync]
+      [proxyObject, notifyInSync],
     ),
     () => {
       const nextSnapshot = snapshot(proxyObject, use)
@@ -143,7 +143,7 @@ export function useSnapshot<T extends object>(
             lastSnapshot.current,
             nextSnapshot,
             lastAffected.current,
-            new WeakMap()
+            new WeakMap(),
           )
         ) {
           // not changed
@@ -154,7 +154,7 @@ export function useSnapshot<T extends object>(
       }
       return nextSnapshot
     },
-    () => snapshot(proxyObject, use)
+    () => snapshot(proxyObject, use),
   )
   inRender = false
   const currAffected = new WeakMap()
@@ -171,6 +171,6 @@ export function useSnapshot<T extends object>(
     currSnapshot,
     currAffected,
     proxyCache,
-    targetCache
+    targetCache,
   )
 }

--- a/src/react/utils/useProxy.ts
+++ b/src/react/utils/useProxy.ts
@@ -24,7 +24,7 @@ import { useSnapshot } from '../../react.ts'
  */
 export function useProxy<T extends object>(
   proxy: T,
-  options?: NonNullable<Parameters<typeof useSnapshot>[1]>
+  options?: NonNullable<Parameters<typeof useSnapshot>[1]>,
 ): T {
   const snapshot = useSnapshot(proxy, options) as T
 

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -50,7 +50,7 @@ type HandlePromise = <P extends Promise<any>>(promise: P) => Awaited<P>
 type CreateSnapshot = <T extends object>(
   target: T,
   version: number,
-  handlePromise?: HandlePromise
+  handlePromise?: HandlePromise,
 ) => T
 
 type RemoveListener = () => void
@@ -91,7 +91,7 @@ const buildProxyFunction = (
       status?: 'pending' | 'fulfilled' | 'rejected'
       value?: Awaited<P>
       reason?: unknown
-    }
+    },
   ) => {
     switch (promise.status) {
       case 'fulfilled':
@@ -108,7 +108,7 @@ const buildProxyFunction = (
   createSnapshot: CreateSnapshot = <T extends object>(
     target: T,
     version: number,
-    handlePromise: HandlePromise = defaultHandlePromise
+    handlePromise: HandlePromise = defaultHandlePromise,
   ): T => {
     const cache = snapCache.get(target)
     if (cache?.[0] === version) {
@@ -127,7 +127,7 @@ const buildProxyFunction = (
       const value = Reflect.get(target, key)
       const { enumerable } = Reflect.getOwnPropertyDescriptor(
         target,
-        key
+        key,
       ) as PropertyDescriptor
       const desc: PropertyDescriptor = {
         value,
@@ -143,12 +143,12 @@ const buildProxyFunction = (
         desc.get = () => handlePromise(value)
       } else if (proxyStateMap.has(value as object)) {
         const [target, ensureVersion] = proxyStateMap.get(
-          value as object
+          value as object,
         ) as ProxyState
         desc.value = createSnapshot(
           target,
           ensureVersion(),
-          handlePromise
+          handlePromise,
         ) as Snapshot<T>
       }
       Object.defineProperty(snap, key, desc)
@@ -202,7 +202,7 @@ const buildProxyFunction = (
     >()
     const addPropListener = (
       prop: string | symbol,
-      propProxyState: ProxyState
+      propProxyState: ProxyState,
     ) => {
       if (import.meta.env?.MODE !== 'production' && propProxyStates.has(prop)) {
         throw new Error('prop listener already exists')
@@ -313,7 +313,7 @@ const buildProxyFunction = (
     Reflect.ownKeys(initialObject).forEach((key) => {
       const desc = Object.getOwnPropertyDescriptor(
         initialObject,
-        key
+        key,
       ) as PropertyDescriptor
       if ('value' in desc) {
         proxyObject[key as keyof T] = initialObject[key as keyof T]
@@ -325,7 +325,7 @@ const buildProxyFunction = (
       Object.defineProperty(baseObject, key, desc)
     })
     return proxyObject
-  }
+  },
 ) =>
   [
     // public functions
@@ -358,7 +358,7 @@ export function getVersion(proxyObject: unknown): number | undefined {
 export function subscribe<T extends object>(
   proxyObject: T,
   callback: (ops: Op[]) => void,
-  notifyInSync?: boolean
+  notifyInSync?: boolean,
 ): () => void {
   const proxyState = proxyStateMap.get(proxyObject as object)
   if (import.meta.env?.MODE !== 'production' && !proxyState) {
@@ -393,7 +393,7 @@ export function subscribe<T extends object>(
 
 export function snapshot<T extends object>(
   proxyObject: T,
-  handlePromise?: HandlePromise
+  handlePromise?: HandlePromise,
 ): Snapshot<T> {
   const proxyState = proxyStateMap.get(proxyObject as object)
   if (import.meta.env?.MODE !== 'production' && !proxyState) {

--- a/src/vanilla/utils/addComputed.ts
+++ b/src/vanilla/utils/addComputed.ts
@@ -10,11 +10,11 @@ export function addComputed_DEPRECATED<T extends object, U extends object>(
   computedFns_FAKE: {
     [K in keyof U]: (snap_FAKE: T) => U[K]
   },
-  targetObject: any = proxyObject
+  targetObject: any = proxyObject,
 ) {
   if (import.meta.env?.MODE !== 'production') {
     console.warn(
-      'addComputed is deprecated. Please consider using `derive`. Falling back to emulation with derive. https://github.com/pmndrs/valtio/pull/201'
+      'addComputed is deprecated. Please consider using `derive`. Falling back to emulation with derive. https://github.com/pmndrs/valtio/pull/201',
     )
   }
   const derivedFns: {

--- a/src/vanilla/utils/devtools.ts
+++ b/src/vanilla/utils/devtools.ts
@@ -23,7 +23,7 @@ type Options = {
 
 export function devtools<T extends object>(
   proxyObject: T,
-  options?: Options
+  options?: Options,
 ): (() => void) | undefined
 
 /**
@@ -31,7 +31,7 @@ export function devtools<T extends object>(
  */
 export function devtools<T extends object>(
   proxyObject: T,
-  name?: string
+  name?: string,
 ): (() => void) | undefined
 
 /**
@@ -47,11 +47,11 @@ export function devtools<T extends object>(
  */
 export function devtools<T extends object>(
   proxyObject: T,
-  options?: Options | string
+  options?: Options | string,
 ) {
   if (typeof options === 'string') {
     console.warn(
-      'string name option is deprecated, use { name }. https://github.com/pmndrs/valtio/pull/400'
+      'string name option is deprecated, use { name }. https://github.com/pmndrs/valtio/pull/400',
     )
     options = { name: options }
   }
@@ -94,7 +94,7 @@ export function devtools<T extends object>(
           type: action,
           updatedAt: new Date().toLocaleString(),
         } as any,
-        snapWithoutDevtools
+        snapWithoutDevtools,
       )
     }
   })
@@ -102,7 +102,7 @@ export function devtools<T extends object>(
     devtools as unknown as {
       // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
       subscribe: (
-        listener: (message: Message) => void
+        listener: (message: Message) => void,
       ) => (() => void) | undefined
     }
   ).subscribe((message) => {
@@ -112,7 +112,7 @@ export function devtools<T extends object>(
       } catch (e) {
         console.error(
           'please dispatch a serializable value that JSON.parse() and proxy() support\n',
-          e
+          e,
         )
       }
     }

--- a/src/vanilla/utils/proxyMap.ts
+++ b/src/vanilla/utils/proxyMap.ts
@@ -36,7 +36,7 @@ type InternalProxyMap<K, V> = Map<K, V> & {
  * state.get(key) //undefined
  */
 export function proxyMap<K, V>(
-  entries?: Iterable<readonly [K, V]> | null
+  entries?: Iterable<readonly [K, V]> | null,
 ): Map<K, V> {
   const map: InternalProxyMap<K, V> = proxy({
     data: Array.from(entries || []) as KeyValRecord<K, V>[],

--- a/src/vanilla/utils/proxyWithComputed.ts
+++ b/src/vanilla/utils/proxyWithComputed.ts
@@ -18,11 +18,11 @@ export function proxyWithComputed_DEPRECATED<
           get: (snap: Snapshot<T>) => U[K]
           set?: (state: T, newValue: U[K]) => void
         }
-  }
+  },
 ) {
   if (import.meta.env?.MODE !== 'production') {
     console.warn(
-      'proxyWithComputed is deprecated. Please follow "Computed Properties" guide in docs.'
+      'proxyWithComputed is deprecated. Please follow "Computed Properties" guide in docs.',
     )
   }
   ;(Object.keys(computedFns) as (keyof U)[]).forEach((key) => {

--- a/src/vanilla/utils/proxyWithHistory.ts
+++ b/src/vanilla/utils/proxyWithHistory.ts
@@ -67,7 +67,7 @@ export function proxyWithHistory<V>(initialValue: V, skipSubscribe = false) {
     undo: () => {
       if (proxyObject.canUndo()) {
         proxyObject.value = (proxyObject.history.wip = proxyObject.clone(
-          proxyObject.history.snapshots[--proxyObject.history.index]
+          proxyObject.history.snapshots[--proxyObject.history.index],
         ) as Snapshot<V>) as V
       }
     },
@@ -76,7 +76,7 @@ export function proxyWithHistory<V>(initialValue: V, skipSubscribe = false) {
     redo: () => {
       if (proxyObject.canRedo()) {
         proxyObject.value = (proxyObject.history.wip = proxyObject.clone(
-          proxyObject.history.snapshots[++proxyObject.history.index]
+          proxyObject.history.snapshots[++proxyObject.history.index],
         ) as Snapshot<V>) as V
       }
     },
@@ -91,7 +91,7 @@ export function proxyWithHistory<V>(initialValue: V, skipSubscribe = false) {
           ops.every(
             (op) =>
               op[1][0] === 'value' &&
-              (op[0] !== 'set' || op[2] !== proxyObject.history.wip)
+              (op[0] !== 'set' || op[2] !== proxyObject.history.wip),
           )
         ) {
           proxyObject.saveHistory()

--- a/src/vanilla/utils/subscribeKey.ts
+++ b/src/vanilla/utils/subscribeKey.ts
@@ -15,7 +15,7 @@ export function subscribeKey<T extends object, K extends keyof T>(
   proxyObject: T,
   key: K,
   callback: (value: T[K]) => void,
-  notifyInSync?: boolean
+  notifyInSync?: boolean,
 ) {
   let prevValue = proxyObject[key]
   return subscribe(
@@ -26,6 +26,6 @@ export function subscribeKey<T extends object, K extends keyof T>(
         callback((prevValue = nextValue))
       }
     },
-    notifyInSync
+    notifyInSync,
   )
 }

--- a/src/vanilla/utils/watch.ts
+++ b/src/vanilla/utils/watch.ts
@@ -34,7 +34,7 @@ let currentCleanups: Set<Cleanup> | undefined
  */
 export function watch(
   callback: WatchCallback,
-  options?: WatchOptions
+  options?: WatchOptions,
 ): Cleanup {
   let alive = true
   const cleanups = new Set<Cleanup>()

--- a/tests/__snapshots__/macro.test.ts.snap
+++ b/tests/__snapshots__/macro.test.ts.snap
@@ -58,7 +58,8 @@ const Component = () => {
         onClick={() => {
           ;(() => ++state.count)()
           ++state.count
-        }}>
+        }}
+      >
         inc
       </button>
       {valtio_macro_snap_state.count}

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -30,7 +30,7 @@ it('delayed increment', async () => {
       <Suspense fallback="loading">
         <Counter />
       </Suspense>
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')
@@ -61,7 +61,7 @@ it('delayed object', async () => {
       <Suspense fallback="loading">
         <Counter />
       </Suspense>
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('text: none')
@@ -77,7 +77,7 @@ it('delayed object update fulfilled', async () => {
   })
   const updateObject = () => {
     state.object = state.object.then((v: any) =>
-      sleep(300).then(() => ({ ...v, count: v.count + 1 }))
+      sleep(300).then(() => ({ ...v, count: v.count + 1 })),
     )
   }
 
@@ -97,7 +97,7 @@ it('delayed object update fulfilled', async () => {
       <Suspense fallback="loading">
         <Counter />
       </Suspense>
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('loading')
@@ -136,7 +136,7 @@ it('delayed falsy value', async () => {
       <Suspense fallback="loading">
         <Counter />
       </Suspense>
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('value: true')

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -19,7 +19,7 @@ it('simple counter', async () => {
   const { getByText, findByText, unmount } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')
@@ -68,7 +68,7 @@ it('no extra re-renders (commits)', async () => {
     <>
       <Counter />
       <Counter2 />
-    </>
+    </>,
   )
 
   await waitFor(() => {
@@ -120,7 +120,7 @@ it('no extra re-renders (render func calls in non strict mode)', async () => {
     <>
       <Counter />
       <Counter2 />
-    </>
+    </>,
   )
 
   await waitFor(() => {
@@ -189,7 +189,7 @@ it('object in object', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')
@@ -216,7 +216,7 @@ it('array in object', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('counts: 0,1,2')
@@ -242,7 +242,7 @@ it('array pop and splice', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('counts: 0,1,2')
@@ -264,13 +264,15 @@ it('array length after direct assignment', async () => {
         <div>counts: {snap.counts.join(',')}</div>
         <div>length: {snap.counts.length}</div>
         <button
-          onClick={() => (obj.counts[obj.counts.length] = obj.counts.length)}>
+          onClick={() => (obj.counts[obj.counts.length] = obj.counts.length)}
+        >
           increment
         </button>
         <button
           onClick={() =>
             (obj.counts[obj.counts.length + 5] = obj.counts.length + 5)
-          }>
+          }
+        >
           jump
         </button>
       </>
@@ -280,7 +282,7 @@ it('array length after direct assignment', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('counts: 0,1,2')
@@ -308,7 +310,7 @@ it('deleting property', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 1')
@@ -335,7 +337,7 @@ it('circular object', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')
@@ -357,7 +359,7 @@ it('circular object with non-proxy object (#375)', async () => {
   const { findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 1')
@@ -385,7 +387,7 @@ it('render from outside', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('anotherCount: 0')
@@ -417,7 +419,7 @@ it('counter with sync option', async () => {
   const { getByText, findByText } = render(
     <>
       <Counter />
-    </>
+    </>,
   )
 
   await findByText('count: 0 (1)')
@@ -442,7 +444,7 @@ it('support undefined property (#439)', async () => {
   const { findByText } = render(
     <StrictMode>
       <Component />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('has prop: true')
@@ -479,7 +481,7 @@ it('sync snapshot between nested components (#460)', async () => {
   const { getByText } = render(
     <StrictMode>
       <Parent />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await waitFor(() => {

--- a/tests/class.test.tsx
+++ b/tests/class.test.tsx
@@ -26,7 +26,7 @@ it('simple class without methods', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')
@@ -83,7 +83,7 @@ it('no extra re-renders with class', async () => {
     <>
       <Counter />
       <Counter2 />
-    </>
+    </>,
   )
 
   await waitFor(() => {
@@ -134,7 +134,7 @@ it('inherited class without methods', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')
@@ -189,7 +189,7 @@ it('class with a method', async () => {
     <>
       <Counter />
       <Counter2 />
-    </>
+    </>,
   )
 
   await waitFor(() => {
@@ -260,7 +260,7 @@ it('inherited class with a method', async () => {
     <>
       <Counter />
       <Counter2 />
-    </>
+    </>,
   )
 
   await waitFor(() => {
@@ -335,7 +335,7 @@ it('no extra re-renders with getters', async () => {
     <>
       <Counter />
       <Counter2 />
-    </>
+    </>,
   )
 
   await waitFor(() => {

--- a/tests/computed.test.tsx
+++ b/tests/computed.test.tsx
@@ -33,7 +33,7 @@ describe('proxyWithComputed', () => {
       },
       {
         doubled: { get: memoize((snap) => computeDouble(snap.count)) },
-      }
+      },
     )
 
     const callback = vi.fn()
@@ -70,7 +70,7 @@ describe('proxyWithComputed', () => {
             state.count = newValue / 2
           },
         },
-      }
+      },
     )
 
     expect(snapshot(state)).toMatchObject({ text: '', count: 0, doubled: 0 })
@@ -111,7 +111,7 @@ describe('proxyWithComputed', () => {
             state.arr = newValue
           },
         },
-      }
+      },
     )
 
     expect(snapshot(state)).toMatchObject({
@@ -143,7 +143,7 @@ describe('proxyWithComputed', () => {
           if (!snap.filter) return snap.texts
           return snap.texts.filter((text) => !text.includes(snap.filter))
         }),
-      }
+      },
     )
 
     const Component = () => {
@@ -159,7 +159,7 @@ describe('proxyWithComputed', () => {
     const { getByText, findByText } = render(
       <StrictMode>
         <Component />
-      </StrictMode>
+      </StrictMode>,
     )
 
     await findByText('filtered: []')
@@ -212,7 +212,7 @@ describe('DEPRECATED addComputed', () => {
 
     const Counter = () => {
       const snap = useSnapshot(
-        state as { count: number; delayedCount: Promise<number> }
+        state as { count: number; delayedCount: Promise<number> },
       )
       return (
         <>
@@ -229,7 +229,7 @@ describe('DEPRECATED addComputed', () => {
         <Suspense fallback="loading">
           <Counter />
         </Suspense>
-      </StrictMode>
+      </StrictMode>,
     )
 
     await findByText('loading')
@@ -248,7 +248,7 @@ describe('DEPRECATED addComputed', () => {
       {
         doubled: (snap) => computeDouble(snap.math.count),
       },
-      state.math
+      state.math,
     )
 
     const callback = vi.fn()
@@ -311,7 +311,7 @@ describe('proxyWithComputed and subscribeKey', () => {
       },
       {
         doubled: (snap) => snap.count * 2,
-      }
+      },
     )
     const handler = vi.fn()
     subscribeKey(state, 'doubled', handler)

--- a/tests/derive.test.tsx
+++ b/tests/derive.test.tsx
@@ -56,7 +56,7 @@ it('derive another proxy', async () => {
     },
     {
       proxy: anotherState,
-    }
+    },
   )
 
   const callback = vi.fn()
@@ -93,7 +93,7 @@ it('derive with self', async () => {
     },
     {
       proxy: state,
-    }
+    },
   )
 
   const callback = vi.fn()
@@ -158,12 +158,12 @@ it('async derive', async () => {
         return get(state).count + 1
       },
     },
-    { proxy: state }
+    { proxy: state },
   )
 
   const Counter = () => {
     const snap = useSnapshot(
-      state as { count: number; delayedCount: Promise<number> }
+      state as { count: number; delayedCount: Promise<number> },
     )
     return (
       <>
@@ -180,7 +180,7 @@ it('async derive', async () => {
       <Suspense fallback="loading">
         <Counter />
       </Suspense>
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('loading')
@@ -198,7 +198,7 @@ it('nested emulation with derive', async () => {
     {
       doubled: (get) => computeDouble(get(state.math).count),
     },
-    { proxy: state.math, sync: true }
+    { proxy: state.math, sync: true },
   )
 
   const callback = vi.fn()
@@ -240,7 +240,7 @@ it('derive with array.pop', async () => {
     {
       nums: (get) => get(state.arr).map((item) => item.n),
     },
-    { proxy: state }
+    { proxy: state },
   )
 
   expect(snapshot(state)).toMatchObject({
@@ -317,7 +317,7 @@ describe('glitch free', () => {
     const { getByText, findByText } = render(
       <>
         <App />
-      </>
+      </>,
     )
 
     await findByText('value: v0: 0, v1: 0, v2: 0 (commits: 1)')
@@ -359,7 +359,7 @@ describe('glitch free', () => {
     const { getByText, findByText } = render(
       <StrictMode>
         <App />
-      </StrictMode>
+      </StrictMode>,
     )
 
     await findByText('value: 0')
@@ -405,7 +405,7 @@ describe('glitch free', () => {
     const { getByText, findByText } = render(
       <StrictMode>
         <App />
-      </StrictMode>
+      </StrictMode>,
     )
 
     await findByText('value: 0')
@@ -433,7 +433,7 @@ describe('two derived properties', () => {
           return 1
         },
       },
-      { proxy: state }
+      { proxy: state },
     )
     derive(
       {
@@ -442,7 +442,7 @@ describe('two derived properties', () => {
           return 1
         },
       },
-      { proxy: state }
+      { proxy: state },
     )
     await Promise.resolve()
     expect(state.derived1).toBeDefined()
@@ -462,7 +462,7 @@ describe('two derived properties', () => {
           return {}
         },
       },
-      { proxy: state }
+      { proxy: state },
     )
     await Promise.resolve()
     expect(state.derived1).toBeDefined()
@@ -478,7 +478,7 @@ describe('two derived properties', () => {
           return {}
         },
       },
-      { proxy: state }
+      { proxy: state },
     )
     derive(
       {
@@ -487,7 +487,7 @@ describe('two derived properties', () => {
           return {}
         },
       },
-      { proxy: state }
+      { proxy: state },
     )
     await Promise.resolve()
     expect(state.derived1).toBeDefined()

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -46,7 +46,7 @@ it('connects to the extension by initialiing', () => {
   render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   expect(extension.init).toHaveBeenLastCalledWith({ count: 0 })
@@ -80,7 +80,7 @@ describe('If there is no extension installed...', () => {
       render(
         <StrictMode>
           <Counter />
-        </StrictMode>
+        </StrictMode>,
       )
     }).not.toThrow()
   })
@@ -100,7 +100,7 @@ describe('If there is no extension installed...', () => {
     render(
       <StrictMode>
         <Counter />
-      </StrictMode>
+      </StrictMode>,
     )
     expect(console.warn).not.toBeCalled()
   })
@@ -120,10 +120,10 @@ describe('If there is no extension installed...', () => {
     render(
       <StrictMode>
         <Counter />
-      </StrictMode>
+      </StrictMode>,
     )
     expect(console.warn).toHaveBeenLastCalledWith(
-      '[Warning] Please install/enable Redux devtools extension'
+      '[Warning] Please install/enable Redux devtools extension',
     )
   })
 
@@ -142,7 +142,7 @@ describe('If there is no extension installed...', () => {
     render(
       <StrictMode>
         <Counter />
-      </StrictMode>
+      </StrictMode>,
     )
     expect(console.warn).not.toBeCalled()
   })
@@ -166,7 +166,7 @@ it('updating state should call devtools.send', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   expect(extension.send).toBeCalledTimes(0)
@@ -199,7 +199,7 @@ describe('when it receives an message of type...', () => {
         <Suspense fallback={'loading'}>
           <Counter />
         </Suspense>
-      </StrictMode>
+      </StrictMode>,
     )
 
     expect(extension.send).toBeCalledTimes(0)
@@ -210,7 +210,7 @@ describe('when it receives an message of type...', () => {
       (extensionSubscriber as (message: any) => void)({
         type: 'ACTION',
         payload: JSON.stringify({ count: 0 }),
-      })
+      }),
     )
     await findByText('count: 0')
     expect(extension.send).toBeCalledTimes(2)
@@ -235,7 +235,7 @@ describe('when it receives an message of type...', () => {
       const { getByText, findByText } = render(
         <StrictMode>
           <Counter />
-        </StrictMode>
+        </StrictMode>,
       )
 
       expect(extension.send).toBeCalledTimes(0)
@@ -248,7 +248,7 @@ describe('when it receives an message of type...', () => {
         (extensionSubscriber as (message: any) => void)({
           type: 'DISPATCH',
           payload: { type: 'COMMIT' },
-        })
+        }),
       )
       await findByText('count: 2')
       expect(extension.init).toBeCalledWith({ count: 2 })
@@ -272,7 +272,7 @@ describe('when it receives an message of type...', () => {
       const { getByText, findByText } = render(
         <StrictMode>
           <Counter />
-        </StrictMode>
+        </StrictMode>,
       )
 
       const nextLiftedState = {
@@ -290,7 +290,7 @@ describe('when it receives an message of type...', () => {
         (extensionSubscriber as (message: any) => void)({
           type: 'DISPATCH',
           payload: { type: 'IMPORT_STATE', nextLiftedState },
-        })
+        }),
       )
       expect(extension.init).toBeCalledWith({ count: 5 })
       await findByText('count: 6')
@@ -315,7 +315,7 @@ describe('when it receives an message of type...', () => {
         const { getByText, findByText } = render(
           <StrictMode>
             <Counter />
-          </StrictMode>
+          </StrictMode>,
         )
 
         expect(extension.send).toBeCalledTimes(0)
@@ -327,7 +327,7 @@ describe('when it receives an message of type...', () => {
             type: 'DISPATCH',
             payload: { type: 'JUMP_TO_ACTION' },
             state: JSON.stringify({ count: 0 }),
-          })
+          }),
         )
         await findByText('count: 0')
         expect(extension.send).toBeCalledTimes(1)

--- a/tests/getter.test.tsx
+++ b/tests/getter.test.tsx
@@ -28,7 +28,7 @@ it('simple object getters', async () => {
     <StrictMode>
       <Counter name="A" />
       <Counter name="B" />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await waitFor(() => {
@@ -70,7 +70,7 @@ it('object getters returning object', async () => {
     <StrictMode>
       <Counter name="A" />
       <Counter name="B" />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await waitFor(() => {

--- a/tests/history.test.tsx
+++ b/tests/history.test.tsx
@@ -22,7 +22,7 @@ it('simple count', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')
@@ -76,7 +76,7 @@ it('count in object', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')
@@ -130,7 +130,7 @@ it('count in nested object', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')
@@ -179,14 +179,16 @@ it('multiple redos at once (#323)', async () => {
           onClick={() => {
             state.undo()
             state.undo()
-          }}>
+          }}
+        >
           undo twice
         </button>
         <button
           onClick={() => {
             state.redo()
             state.redo()
-          }}>
+          }}
+        >
           redo twice
         </button>
       </>
@@ -196,7 +198,7 @@ it('multiple redos at once (#323)', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')
@@ -232,7 +234,8 @@ it('nested array (#516)', async () => {
         <button
           onClick={() => {
             state.undo()
-          }}>
+          }}
+        >
           undo
         </button>
         <button
@@ -240,7 +243,8 @@ it('nested array (#516)', async () => {
             if (state.value.level0Values[1]) {
               state.value.level0Values[1].level1Values[0] = 10
             }
-          }}>
+          }}
+        >
           change 2 to 10
         </button>
         <button
@@ -248,7 +252,8 @@ it('nested array (#516)', async () => {
             if (state.value.level0Values[1]) {
               state.value.level0Values[1].level1Values[0] = 11
             }
-          }}>
+          }}
+        >
           change 10 to 11
         </button>
         <button
@@ -256,7 +261,8 @@ it('nested array (#516)', async () => {
             if (state.value.level0Values[0]) {
               state.value.level0Values[0].level1Values[0] = 12
             }
-          }}>
+          }}
+        >
           change 0 to 12
         </button>
       </>
@@ -266,40 +272,40 @@ it('nested array (#516)', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <NestedArray />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText(
-    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[2,3]}]}'
+    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[2,3]}]}',
   )
 
   fireEvent.click(getByText('change 2 to 10'))
   await findByText(
-    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[10,3]}]}'
+    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[10,3]}]}',
   )
 
   fireEvent.click(getByText('change 10 to 11'))
   await findByText(
-    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[11,3]}]}'
+    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[11,3]}]}',
   )
 
   fireEvent.click(getByText('undo')) // => 11 back to 10
   await findByText(
-    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[10,3]}]}'
+    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[10,3]}]}',
   )
 
   fireEvent.click(getByText('change 0 to 12'))
   await findByText(
-    'values: {"level0Values":[{"level1Values":[12,1]},{"level1Values":[10,3]}]}'
+    'values: {"level0Values":[{"level1Values":[12,1]},{"level1Values":[10,3]}]}',
   )
 
   fireEvent.click(getByText('undo')) // => 12 back to 0
   await findByText(
-    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[10,3]}]}'
+    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[10,3]}]}',
   )
 
   fireEvent.click(getByText('undo')) // => 10 back to 2
   await findByText(
-    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[2,3]}]}'
+    'values: {"level0Values":[{"level1Values":[0,1]},{"level1Values":[2,3]}]}',
   )
 })

--- a/tests/macro-vite.test.ts
+++ b/tests/macro-vite.test.ts
@@ -31,8 +31,8 @@ const Component = () => {
 }
 `,
       'test.ts',
-      env
-    )
+      env,
+    ),
   ).toMatchSnapshot()
 })
 
@@ -59,7 +59,7 @@ const Component = () => {
 }
 `,
       'test.ts',
-      env
-    )
+      env,
+    ),
   ).toMatchSnapshot()
 })

--- a/tests/mapset.test.tsx
+++ b/tests/mapset.test.tsx
@@ -19,7 +19,7 @@ it('unsupported map', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')
@@ -45,7 +45,7 @@ it('unsupported set', async () => {
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 1,2,3')

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -114,13 +114,13 @@ describe('features parity with native Map', () => {
       const expectOutputToMatch = () => {
         expect(map.size).toStrictEqual(nativeMap.size)
         expect(Array.from(map.values())).toStrictEqual(
-          Array.from(nativeMap.values())
+          Array.from(nativeMap.values()),
         )
         expect(Array.from(map.keys())).toStrictEqual(
-          Array.from(nativeMap.keys())
+          Array.from(nativeMap.keys()),
         )
         expect(Array.from(map.entries())).toStrictEqual(
-          Array.from(nativeMap.entries())
+          Array.from(nativeMap.entries()),
         )
         expect(JSON.stringify(map)).toStrictEqual(JSON.stringify(nativeMap))
 
@@ -180,11 +180,11 @@ describe('features parity with native Map', () => {
 
     expect(map.size).toStrictEqual(nativeMap.size)
     expect(Array.from(map.values())).toStrictEqual(
-      Array.from(nativeMap.values())
+      Array.from(nativeMap.values()),
     )
     expect(Array.from(map.keys())).toStrictEqual(Array.from(nativeMap.keys()))
     expect(Array.from(map.entries())).toStrictEqual(
-      Array.from(nativeMap.entries())
+      Array.from(nativeMap.entries()),
     )
   })
 })
@@ -208,7 +208,7 @@ describe('clear map', () => {
       const { getByText } = render(
         <StrictMode>
           <TestComponent />
-        </StrictMode>
+        </StrictMode>,
       )
 
       expect(state.size).toBeGreaterThan(0)
@@ -243,7 +243,7 @@ describe('add value', () => {
       const { getByText } = render(
         <StrictMode>
           <TestComponent />
-        </StrictMode>
+        </StrictMode>,
       )
 
       getByText('size: 0')
@@ -291,7 +291,7 @@ describe('delete', () => {
       const { getByText } = render(
         <StrictMode>
           <TestComponent />
-        </StrictMode>
+        </StrictMode>,
       )
 
       getByText(`size: ${state.map.size}`)
@@ -315,7 +315,7 @@ describe('proxyMap internal', () => {
   it('should list only enumerable properties', () => {
     const notEnumerableProps = ['data', 'size', 'toJSON']
     expect(
-      Object.keys(proxyMap()).some((k) => notEnumerableProps.includes(k))
+      Object.keys(proxyMap()).some((k) => notEnumerableProps.includes(k)),
     ).toBe(false)
   })
 })

--- a/tests/proxySet.test.tsx
+++ b/tests/proxySet.test.tsx
@@ -117,13 +117,13 @@ describe('features parity with native Set', () => {
       const expectOutputToMatch = () => {
         expect(set.size).toStrictEqual(nativeSet.size)
         expect(Array.from(set.values())).toStrictEqual(
-          Array.from(nativeSet.values())
+          Array.from(nativeSet.values()),
         )
         expect(Array.from(set.keys())).toStrictEqual(
-          Array.from(nativeSet.keys())
+          Array.from(nativeSet.keys()),
         )
         expect(Array.from(set.entries())).toStrictEqual(
-          Array.from(nativeSet.entries())
+          Array.from(nativeSet.entries()),
         )
         expect(JSON.stringify(set)).toStrictEqual(JSON.stringify(nativeSet))
 
@@ -153,7 +153,7 @@ describe('features parity with native Set', () => {
       const [valueToDeleteFromNativeSet] = nativeSet
 
       expect(set.delete(valueToDeleteFromSet)).toBe(
-        nativeSet.delete(valueToDeleteFromNativeSet)
+        nativeSet.delete(valueToDeleteFromNativeSet),
       )
 
       expectOutputToMatch()
@@ -224,7 +224,7 @@ describe('clear set', () => {
       const { getByText } = render(
         <StrictMode>
           <TestComponent />
-        </StrictMode>
+        </StrictMode>,
       )
 
       getByText(`size: ${state.set.size}`)
@@ -258,7 +258,7 @@ describe('add value', () => {
       const { getByText } = render(
         <StrictMode>
           <TestComponent />
-        </StrictMode>
+        </StrictMode>,
       )
 
       getByText('size: 0')
@@ -299,7 +299,7 @@ describe('delete', () => {
       const { getByText } = render(
         <StrictMode>
           <TestComponent />
-        </StrictMode>
+        </StrictMode>,
       )
 
       getByText(`size: ${state.set.size}`)
@@ -331,7 +331,7 @@ describe('proxySet internal', () => {
   it('should list only enumerable properties', () => {
     const notEnumerableProps = ['data', 'size', 'toJSON']
     expect(
-      Object.keys(proxySet()).some((k) => notEnumerableProps.includes(k))
+      Object.keys(proxySet()).some((k) => notEnumerableProps.includes(k)),
     ).toBe(false)
   })
 })

--- a/tests/ref.test.tsx
+++ b/tests/ref.test.tsx
@@ -25,7 +25,7 @@ it('should trigger re-render setting objects with ref wrapper', async () => {
   const { getByText, findByText } = render(
     <>
       <Counter />
-    </>
+    </>,
   )
 
   await findByText('count: 0 (1)')
@@ -52,7 +52,7 @@ it('should not track object wrapped in ref assigned to proxy state', async () =>
   const { getByText, findByText } = render(
     <StrictMode>
       <Component />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('original')
@@ -77,7 +77,7 @@ it('should not trigger re-render when mutating object wrapped in ref', async () 
   const { getByText, findByText } = render(
     <StrictMode>
       <Counter />
-    </StrictMode>
+    </StrictMode>,
   )
 
   await findByText('count: 0')

--- a/tests/watch.test.tsx
+++ b/tests/watch.test.tsx
@@ -91,7 +91,7 @@ describe('watch', () => {
       (get) => {
         get(reference)
       },
-      { sync: true }
+      { sync: true },
     )
 
     reference.value = 'Update'


### PR DESCRIPTION
> The prettier config was defined back in some time, and prettier has been updated since then.
I think we should follow the default config as much as possible.

https://github.com/pmndrs/zustand/pull/2193 