### PR TITLE
feat: Support promise in watch util

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -357,7 +357,7 @@ export function getVersion(proxyObject: unknown): number | undefined {
 
 export function subscribe<T extends object>(
   proxyObject: T,
-  callback: (ops: Op[]) => void,
+  callback: (ops: Op[]) => void | Promise<void>,
   notifyInSync?: boolean,
 ): () => void {
   const proxyState = proxyStateMap.get(proxyObject as object)


### PR DESCRIPTION
## Related Issues or Discussions
https://github.com/pmndrs/valtio/issues/507


## Summary
Updates the watch util to support a promise callback. Proxies are subscribed to immediately to improve the time to first callback. This way a proxy can be subscribed to before the promise finishes fully.

## Check List

- [x] `yarn run prettier` for formatting code and docs