### PR TITLE
refactor(types): make Snapshot<T> use read-only collections

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -18,26 +18,22 @@ type Op =
 type Listener = (op: Op, nextVersion: number) => void
 
 type Primitive = string | number | boolean | null | undefined | symbol | bigint
-
-type SnapshotIgnore =
-  | Date
-  | Map<any, any>
-  | Set<any>
-  | WeakMap<any, any>
-  | WeakSet<any>
-  | AsRef
-  | Error
-  | RegExp
-  | AnyFunction
-  | Primitive
+type SnapshotIgnore = Date | AsRef | Error | RegExp | AnyFunction | Primitive
+type Collection = Map<any, any> | Set<any> | WeakMap<any, any> | WeakSet<any>
+type Readonly<T extends Collection> = Omit<
+  T,
+  'set' | 'add' | 'delete' | 'clear'
+>
 
 type Snapshot<T> = T extends SnapshotIgnore
   ? T
   : T extends Promise<unknown>
     ? Awaited<T>
-    : T extends object
-      ? { readonly [K in keyof T]: Snapshot<T[K]> }
-      : T
+    : T extends Collection
+      ? Readonly<T>
+      : T extends object
+        ? { readonly [K in keyof T]: Snapshot<T[K]> }
+        : T
 
 /**
  * This is not a public API.

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -18,22 +18,26 @@ type Op =
 type Listener = (op: Op, nextVersion: number) => void
 
 type Primitive = string | number | boolean | null | undefined | symbol | bigint
-type SnapshotIgnore = Date | AsRef | Error | RegExp | AnyFunction | Primitive
-type Collection = Map<any, any> | Set<any> | WeakMap<any, any> | WeakSet<any>
-type Readonly<T extends Collection> = Omit<
-  T,
-  'set' | 'add' | 'delete' | 'clear'
->
+
+type SnapshotIgnore =
+  | Date
+  | Map<any, any>
+  | Set<any>
+  | WeakMap<any, any>
+  | WeakSet<any>
+  | AsRef
+  | Error
+  | RegExp
+  | AnyFunction
+  | Primitive
 
 type Snapshot<T> = T extends SnapshotIgnore
   ? T
   : T extends Promise<unknown>
     ? Awaited<T>
-    : T extends Collection
-      ? Readonly<T>
-      : T extends object
-        ? { readonly [K in keyof T]: Snapshot<T[K]> }
-        : T
+    : T extends object
+      ? { readonly [K in keyof T]: Snapshot<T[K]> }
+      : T
 
 /**
  * This is not a public API.

--- a/src/vanilla/utils/proxyMap.ts
+++ b/src/vanilla/utils/proxyMap.ts
@@ -35,9 +35,7 @@ type InternalProxyMap<K, V> = Map<K, V> & {
  * state.set(key, "value")
  * state.get(key) //undefined
  */
-export function proxyMap<K, V>(
-  entries?: Iterable<readonly [K, V]> | null,
-): Map<K, V> {
+export function proxyMap<K, V>(entries?: Iterable<readonly [K, V]> | null) {
   const map: InternalProxyMap<K, V> = proxy({
     data: Array.from(entries || []) as KeyValRecord<K, V>[],
     has(key) {
@@ -107,5 +105,7 @@ export function proxyMap<K, V>(
   })
   Object.seal(map)
 
-  return map as Map<K, V>
+  return map as unknown as Map<K, V> & {
+    $$valtioSnapshot: Omit<Map<K, V>, 'set' | 'delete' | 'clear'>
+  }
 }

--- a/src/vanilla/utils/proxySet.ts
+++ b/src/vanilla/utils/proxySet.ts
@@ -21,7 +21,7 @@ type InternalProxySet<T> = Set<T> & {
  *   set: proxySet()
  * })
  */
-export function proxySet<T>(initialValues?: Iterable<T> | null): Set<T> {
+export function proxySet<T>(initialValues?: Iterable<T> | null) {
   const set: InternalProxySet<T> = proxy({
     data: Array.from(new Set(initialValues)),
     has(value) {
@@ -92,5 +92,7 @@ export function proxySet<T>(initialValues?: Iterable<T> | null): Set<T> {
 
   Object.seal(set)
 
-  return set as Set<T>
+  return set as unknown as Set<T> & {
+    $$valtioSnapshot: Omit<Set<T>, 'add' | 'delete' | 'clear'>
+  }
 }

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -100,9 +100,7 @@ describe('snapsoht typings', () => {
           undefined: undefined
           bool: boolean
           someFunction(): number
-          ref: {
-            $$valtioRef: true
-          }
+          ref: { x: unknown } & { $$valtioSnapshot: { x: unknown } }
         }>,
         {
           readonly string: string
@@ -111,9 +109,7 @@ describe('snapsoht typings', () => {
           readonly undefined: undefined
           readonly bool: boolean
           readonly someFunction: () => number
-          readonly ref: {
-            $$valtioRef: true
-          }
+          readonly ref: { x: unknown }
         }
       >
     >(true)


### PR DESCRIPTION
hey! this PR changes the `Snapshot<T>` type so that any collection types (Map, Set, WeakMap, & WeakSet) will be made read-only as well (i.e. omit mutating methods). this helps catch mistakes like the following:

```js
const snap = useSnapshot<{ users: Set<User> }>(store)
snap.users.delete(user.id) // now, "Property 'delete' does not exist"
```

this is *technically* a build-breaking change, just like adding `readonly` [was](#327), but any users affected by typed immutability have probably fixed it already. i decided to go with two internal types (`Collection` and `Readonly<T>`, which uses `Omit<T>`), resulting in slightly uglier type names (e.g. `Readonly<Set<T>>` vs. the native `ReadonlySet<T>`), but nicer typedefs.

- [x] `npm run prettier`