### PR TITLE
replace listeners on an object that is replaced

### DIFF
--- a/tests/subscribe.test.tsx
+++ b/tests/subscribe.test.tsx
@@ -183,6 +183,24 @@ describe('subscribe', () => {
     await Promise.resolve()
     expect(handler).toBeCalledTimes(0)
   })
+
+  it('should keep a subscription when a nested object is replaced', async () => {
+    const state = proxy({ obj: { nested: 'prop' } })
+    const handler = vi.fn()
+
+    subscribe(state.obj, handler)
+
+    state.obj = { nested: 'new prop' }
+
+    await Promise.resolve()
+    expect(handler).toBeCalledTimes(1)
+
+    state.obj = { nested: 'new propss' }
+
+    await Promise.resolve()
+
+    expect(handler).toBeCalledTimes(2)
+  })
 })
 
 describe('subscribeKey', () => {


### PR DESCRIPTION
## Related Issues or Discussions

Relates to #449

## Summary

This change allows for listeners to be resubscribed to objects that are replaced.

These changes allow the following code to not lose the subscription to the object that previously would lose the subscription:

```ts
const unsubscribe = subscribe(state.myObject, () => {
  // callback to run whenever object changes
  if(needToReplace) {
    state.myObject = newObjectState
  }
})
```

## Check List

- [x] `yarn run prettier` for formatting code and docs
