### PR TITLE
[v2]: explicit package.json type field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "valtio",
   "private": true,
+  "type": "commonjs",
   "version": "2.0.0-beta.3",
   "publishConfig": {
     "tag": "next"


### PR DESCRIPTION
https://publint.dev/rules#use_type

> a new --experimental-default-type flag to flip the default module system from "CJS-as-default" to "ESM-as-default".

wow, that will cause many problems...