### PR TITLE
feat(utils): add subscribeKeys

### DIFF
--- a/src/vanilla/utils.ts
+++ b/src/vanilla/utils.ts
@@ -1,4 +1,5 @@
 export { subscribeKey } from './utils/subscribeKey.ts'
+export { subscribeKeys } from './utils/subscribeKeys.ts'
 export { watch } from './utils/watch.ts'
 export { devtools } from './utils/devtools.ts'
 export { derive, underive, unstable_deriveSubscriptions } from 'derive-valtio'

--- a/src/vanilla/utils/subscribeKey.ts
+++ b/src/vanilla/utils/subscribeKey.ts
@@ -9,12 +9,12 @@ import { subscribe } from '../../vanilla.ts'
  *
  * @example
  * import { subscribeKey } from 'valtio/utils'
- * subscribeKey(state, 'count', (v) => console.log('state.count has changed to', v))
+ * subscribeKey(state, 'count', (v, prev) => console.log('state.count has changed from', prev, 'to', v))
  */
 export function subscribeKey<T extends object, K extends keyof T>(
   proxyObject: T,
   key: K,
-  callback: (value: T[K]) => void,
+  callback: (value: T[K], previous?: T[K]) => void,
   notifyInSync?: boolean,
 ) {
   let prevValue = proxyObject[key]
@@ -23,7 +23,8 @@ export function subscribeKey<T extends object, K extends keyof T>(
     () => {
       const nextValue = proxyObject[key]
       if (!Object.is(prevValue, nextValue)) {
-        callback((prevValue = nextValue))
+        callback(nextValue, prevValue)
+        prevValue = nextValue
       }
     },
     notifyInSync,

--- a/src/vanilla/utils/subscribeKeys.ts
+++ b/src/vanilla/utils/subscribeKeys.ts
@@ -1,0 +1,40 @@
+import { subscribe } from '../../vanilla.ts'
+
+/**
+ * subscribeKeys
+ *
+ * The subscribeKeys utility enables subscription to multiple primitive subproperties of a given state proxy.
+ * Subscriptions created with subscribeKeys will only fire when any of the specified properties change.
+ * notifyInSync: same as the parameter to subscribe(); true disables batching of subscriptions.
+ *
+ * @example
+ * import { subscribeKeys } from 'valtio/utils'
+ * subscribeKey(state, ['name', 'surname'], (v, old) => console.log('state.surname has changed from', old[1], 'to', v[1]))
+ */
+export function subscribeKeys<
+  T extends object,
+  K extends ReadonlyArray<keyof T>,
+  V extends {
+    [I in keyof K]: T[K[I]];
+  }
+>(
+  proxyObject: T,
+  keys: K,
+  callback: (values: V, prevValues?: V) => void,
+  notifyInSync?: boolean,
+) {
+  let prevValues = keys.map((key) => proxyObject[key]) as unknown as V;
+  return subscribe(
+    proxyObject,
+    () => {
+      const nextValues = keys.map((key) => proxyObject[key]) as unknown as V;
+      if (
+        nextValues.some((nextValue, i) => !Object.is(prevValues[i], nextValue))
+      ) {
+        callback(nextValues, prevValues);
+        prevValues = nextValues;
+      }
+    },
+    notifyInSync,
+  )
+}

--- a/src/vanilla/utils/subscribeKeys.ts
+++ b/src/vanilla/utils/subscribeKeys.ts
@@ -9,7 +9,7 @@ import { subscribe } from '../../vanilla.ts'
  *
  * @example
  * import { subscribeKeys } from 'valtio/utils'
- * subscribeKey(state, ['name', 'surname'], (v, old) => console.log('state.surname has changed from', old[1], 'to', v[1]))
+ * subscribeKey(state, ['width', 'height'], (v, old) => console.log('area has changed from', old[0] * old[1], 'to', v[0] * v[1]))
  */
 export function subscribeKeys<
   T extends object,

--- a/src/vanilla/utils/subscribeKeys.ts
+++ b/src/vanilla/utils/subscribeKeys.ts
@@ -15,24 +15,24 @@ export function subscribeKeys<
   T extends object,
   K extends ReadonlyArray<keyof T>,
   V extends {
-    [I in keyof K]: T[K[I]];
-  }
+    [I in keyof K]: T[K[I]]
+  },
 >(
   proxyObject: T,
   keys: K,
   callback: (values: V, prevValues?: V) => void,
   notifyInSync?: boolean,
 ) {
-  let prevValues = keys.map((key) => proxyObject[key]) as unknown as V;
+  let prevValues = keys.map((key) => proxyObject[key]) as unknown as V
   return subscribe(
     proxyObject,
     () => {
-      const nextValues = keys.map((key) => proxyObject[key]) as unknown as V;
+      const nextValues = keys.map((key) => proxyObject[key]) as unknown as V
       if (
         nextValues.some((nextValue, i) => !Object.is(prevValues[i], nextValue))
       ) {
-        callback(nextValues, prevValues);
-        prevValues = nextValues;
+        callback(nextValues, prevValues)
+        prevValues = nextValues
       }
     },
     notifyInSync,


### PR DESCRIPTION
## Summary
New utility function based on the current `subscribeKey` that allows subscriptions to multiple properties of a proxy.

This PR also **adds an optional second argument to the callback** function from `subscribeKey`, and therefore the new `subscribeKeys` to provide the previous value of the changed property.

I felt this utility was needed when I had to subscribe to a proxy that changed multiple properties at once, and I needed those changes to execute a single callback.


## Usage
```ts
import { subscribeKeys } from 'valtio/utils'

const state = proxy({ width: 0, height: 0 })
subscribeKeys(state, ['width', 'height'], ([width, height], [oldWidth, oldHeight]) =>
  console.log('Area has changed from', oldWidth * oldHeight, 'to', width * height),
)
```

## Check List

- [x] `yarn run prettier` for formatting code and docs
