### PR TITLE
docs - Added a note in how-tos/reset on how to use structuredClone

### DIFF
--- a/docs/how-tos/how-to-reset-state.mdx
+++ b/docs/how-tos/how-to-reset-state.mdx
@@ -66,4 +66,4 @@ const reset = () => {
 }
 ```
 
-See also [title: 'How to Migrate to v2 from v1'](../guides/migrating-to-v2.mdx#impure-proxyobj).
+See also: ['How to Migrate to v2 from v1'](../guides/migrating-to-v2.mdx#impure-proxyobj).

--- a/docs/how-tos/how-to-reset-state.mdx
+++ b/docs/how-tos/how-to-reset-state.mdx
@@ -53,7 +53,7 @@ const reset = () => {
 }
 ```
 
-In valtio v2, the `proxy` function [no longer clones the initial state]('../guides/migrating-to-v2.mdx'). Instead, it uses the original object directly. This means that `structuredClone` is no longer a drop in replacement for `_.cloneDeep` and will throw an error. To fix this, you can use `structuredClone` to clone the initial state that you pass to into `proxy`.
+In valtio v2, the `proxy` function [no longer clones the initial state]('../guides/migrating-to-v2.mdx'). Instead, it uses the original object directly. It is not recommended that you reuse the object that you pass into the proxy function. If you use `structuredClone` that object, it will throw an error. `_.cloneDeep` won't give you an error, but it could produce unwatned results. To fix this, you can clone the intial state object that you pass to into `proxy`. You can do this with `_.cloneDeep`, `structuredClone`, or the utility function `deepClone` from `valtio/utils`. Example below.
 
 ```js
 // v2
@@ -65,3 +65,5 @@ const reset = () => {
   state.obj = structuredClone(initialObj)
 }
 ```
+
+See also [title: 'How to Migrate to v2 from v1']('../guides/migrating-to-v2.mdx').

--- a/docs/how-tos/how-to-reset-state.mdx
+++ b/docs/how-tos/how-to-reset-state.mdx
@@ -35,7 +35,7 @@ const reset = () => {
 }
 ```
 
->[!NOTE]
+> [!NOTE]
 > Using `structuredClone()`
 
 In 2022, there was a new global function added called `structuredClone` that is widely available in most modern browsers. While this function and `_.cloneDeep` from lodash seem to do the same thing, their implementations are quite different.

--- a/docs/how-tos/how-to-reset-state.mdx
+++ b/docs/how-tos/how-to-reset-state.mdx
@@ -34,3 +34,34 @@ const reset = () => {
   state.obj = _.cloneDeep(initialObj)
 }
 ```
+
+>[!NOTE]
+> Using `structuredClone()`
+
+In 2022, there was a new global function added called `structuredClone` that is widely available in most modern browsers. While this function and `_.cloneDeep` from lodash seem to do the same thing, their implementations are quite different.
+
+In valtio v1, `proxy` cloned the object used for inital state under the hood. Because the original object isn't used, `structuredClone` works just fine as a drop in replacement for `_.cloneDeep`.
+
+```js
+// v1
+const initialObj = {...}
+
+const state = proxy({ obj: initialObj })
+
+const reset = () => {
+  state.obj = structuredClone(initialObj)
+}
+```
+
+In valtio v2, the `proxy` function [no longer clones the initial state]('../guides/migrating-to-v2.mdx'). Instead, it uses the original object directly. This means that `structuredClone` is no longer a drop in replacement for `_.cloneDeep` and will throw an error. To fix this, you can use `structuredClone` to clone the initial state that you pass to into `proxy`.
+
+```js
+// v2
+const initialObj = {...}
+
+const state = proxy(structuredClone(initialObj))
+
+const reset = () => {
+  state.obj = structuredClone(initialObj)
+}
+```

--- a/docs/how-tos/how-to-reset-state.mdx
+++ b/docs/how-tos/how-to-reset-state.mdx
@@ -53,7 +53,7 @@ const reset = () => {
 }
 ```
 
-In valtio v2, the `proxy` function [no longer clones the initial state]('/docs/guides/migrating-to-v2.mdx'). Instead, it uses the original object directly. It is not recommended that you reuse the object that you pass into the proxy function. If you use `structuredClone` that object, it will throw an error. `_.cloneDeep` won't give you an error, but it could produce unwatned results. To fix this, you can clone the intial state object that you pass to into `proxy`. You can do this with `_.cloneDeep`, `structuredClone`, or the utility function `deepClone` from `valtio/utils`. Example below.
+In valtio v2, the `proxy` function [no longer clones the initial state](../guides/migrating-to-v2.mdx). Instead, it uses the original object directly. It is not recommended that you reuse the object that you pass into the proxy function. If you use `structuredClone` that object, it will throw an error. `_.cloneDeep` won't give you an error, but it could produce unwatned results. To fix this, you can clone the intial state object that you pass to into `proxy`. You can do this with `_.cloneDeep`, `structuredClone`, or the utility function `deepClone` from `valtio/utils`. Example below.
 
 ```js
 // v2
@@ -66,4 +66,4 @@ const reset = () => {
 }
 ```
 
-See also [title: 'How to Migrate to v2 from v1']('/docs/guides/migrating-to-v2.mdx#impure-proxyobj').
+See also [title: 'How to Migrate to v2 from v1'](../guides/migrating-to-v2.mdx#impure-proxyobj).

--- a/docs/how-tos/how-to-reset-state.mdx
+++ b/docs/how-tos/how-to-reset-state.mdx
@@ -7,23 +7,26 @@ title: 'How to reset state'
 In some cases, you might want to reset the state in your proxy instance to its initial values. For example, you are storing form values or some other ephemeral UI state that you want to reset. It turns out this is quite simple to do!
 
 ```js
+import { proxy } from 'valtio'
+import { deepClone } from 'valtio/utils'
+
 const initialObj = {
   text: 'hello',
   arr: [1, 2, 3],
   obj: { a: 'b' },
 }
 
-const state = proxy(initialObj)
+const state = proxy(deepClone(initialObj))
 
 const reset = () => {
-  const resetObj = _.cloneDeep(initialObj)
+  const resetObj = deepCLone(initialObj)
   Object.keys(resetObj).forEach((key) => {
     state[key] = resetObj[key]
   })
 }
 ```
 
-Note that we're using the [cloneDeep](https://lodash.com/docs/4.17.15#cloneDeep) utility function from `lodash` to copy the initial object in the `reset` function. This allows Valtio to update correctly when the value of a key is an object. If you prefer `underscore` or some similar JS utility library, feel free to use that instead.
+Note that we're using the `deepClone()` utility function from `valtio/utils` to copy the initial object in _both_ the `reset` function and the `state` proxy. Using deepClone in the proxy function is a new requirement in v2. Valtio no longer clones the initial state by default. If you reuse the object you pass into the proxy function, you may get unexpected results.
 
 Alternatively, you can store the object in another object, which make the reset logic easier:
 
@@ -31,39 +34,11 @@ Alternatively, you can store the object in another object, which make the reset 
 const state = proxy({ obj: initialObj })
 
 const reset = () => {
-  state.obj = _.cloneDeep(initialObj)
+  state.obj = cloneDeep(initialObj)
 }
 ```
 
 > [!NOTE]
 > Using `structuredClone()`
 
-In 2022, there was a new global function added called `structuredClone` that is widely available in most modern browsers. While this function and `_.cloneDeep` from lodash seem to do the same thing, their implementations are quite different.
-
-In valtio v1, `proxy` cloned the object used for inital state under the hood. Because the original object isn't used, `structuredClone` works just fine as a drop in replacement for `_.cloneDeep`.
-
-```js
-// v1
-const initialObj = {...}
-
-const state = proxy({ obj: initialObj })
-
-const reset = () => {
-  state.obj = structuredClone(initialObj)
-}
-```
-
-In valtio v2, the `proxy` function [no longer clones the initial state](../guides/migrating-to-v2.mdx). Instead, it uses the original object directly. It is not recommended that you reuse the object that you pass into the proxy function. If you use `structuredClone` that object, it will throw an error. `_.cloneDeep` won't give you an error, but it could produce unwatned results. To fix this, you can clone the intial state object that you pass to into `proxy`. You can do this with `_.cloneDeep`, `structuredClone`, or the utility function `deepClone` from `valtio/utils`. Example below.
-
-```js
-// v2
-const initialObj = {...}
-
-const state = proxy(structuredClone(initialObj))
-
-const reset = () => {
-  state.obj = structuredClone(initialObj)
-}
-```
-
-See also: ['How to Migrate to v2 from v1'](../guides/migrating-to-v2.mdx#impure-proxyobj).
+In 2022, there was a new global function added called `structuredClone` that is widely available in most modern browsers. You can use `structuredClone` in the same way as `deepClone` above, however `deepClone` is preferred as it will be aware of any `ref`s in your state.

--- a/docs/how-tos/how-to-reset-state.mdx
+++ b/docs/how-tos/how-to-reset-state.mdx
@@ -53,7 +53,7 @@ const reset = () => {
 }
 ```
 
-In valtio v2, the `proxy` function [no longer clones the initial state]('../guides/migrating-to-v2.mdx'). Instead, it uses the original object directly. It is not recommended that you reuse the object that you pass into the proxy function. If you use `structuredClone` that object, it will throw an error. `_.cloneDeep` won't give you an error, but it could produce unwatned results. To fix this, you can clone the intial state object that you pass to into `proxy`. You can do this with `_.cloneDeep`, `structuredClone`, or the utility function `deepClone` from `valtio/utils`. Example below.
+In valtio v2, the `proxy` function [no longer clones the initial state]('/docs/guides/migrating-to-v2.mdx'). Instead, it uses the original object directly. It is not recommended that you reuse the object that you pass into the proxy function. If you use `structuredClone` that object, it will throw an error. `_.cloneDeep` won't give you an error, but it could produce unwatned results. To fix this, you can clone the intial state object that you pass to into `proxy`. You can do this with `_.cloneDeep`, `structuredClone`, or the utility function `deepClone` from `valtio/utils`. Example below.
 
 ```js
 // v2
@@ -66,4 +66,4 @@ const reset = () => {
 }
 ```
 
-See also [title: 'How to Migrate to v2 from v1']('../guides/migrating-to-v2.mdx').
+See also [title: 'How to Migrate to v2 from v1']('/docs/guides/migrating-to-v2.mdx#impure-proxyobj').


### PR DESCRIPTION
## Related Bug Reports or Discussions
N/A
Fixes #
N/A
## Summary
Added example on how to use structuredClone in v2 and the reasoning behind why it's different than v1.


## Check List

- [ x ] `pnpm run prettier` for formatting code and docs
