### PR TITLE
fix(docs): changed cloneDeep to deepClone

### DIFF
--- a/docs/how-tos/how-to-reset-state.mdx
+++ b/docs/how-tos/how-to-reset-state.mdx
@@ -19,7 +19,7 @@ const initialObj = {
 const state = proxy(deepClone(initialObj))
 
 const reset = () => {
-  const resetObj = deepCLone(initialObj)
+  const resetObj = deepClone(initialObj)
   Object.keys(resetObj).forEach((key) => {
     state[key] = resetObj[key]
   })

--- a/docs/how-tos/how-to-reset-state.mdx
+++ b/docs/how-tos/how-to-reset-state.mdx
@@ -34,7 +34,7 @@ Alternatively, you can store the object in another object, which make the reset 
 const state = proxy({ obj: initialObj })
 
 const reset = () => {
-  state.obj = cloneDeep(initialObj)
+  state.obj = deepClone(initialObj)
 }
 ```
 


### PR DESCRIPTION
## Related Bug Reports or Discussions
N/A
Fixes #
N/A
## Summary
Changed `cloneDeep` to `deepClone`. Oversight from previous PR.


## Check List

- [ x ] `pnpm run prettier` for formatting code and docs
