### PR TITLE
fixed issue with .has() when new value is added and then deleted or c…

### DIFF
--- a/src/vanilla/utils/proxyMap.ts
+++ b/src/vanilla/utils/proxyMap.ts
@@ -87,10 +87,9 @@ export function proxyMap<K, V>(entries?: Iterable<[K, V]> | undefined | null) {
     },
     has(key: K) {
       const map = getMapForThis(this)
-      const exists = map.has(key)
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       this.data.length // touch property for tracking
-      return exists
+      return map.has(key)
     },
     set(key: K, value: V) {
       if (!isProxy(this)) {

--- a/src/vanilla/utils/proxyMap.ts
+++ b/src/vanilla/utils/proxyMap.ts
@@ -88,10 +88,8 @@ export function proxyMap<K, V>(entries?: Iterable<[K, V]> | undefined | null) {
     has(key: K) {
       const map = getMapForThis(this)
       const exists = map.has(key)
-      if (!exists) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        this.index // touch property for tracking
-      }
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      this.data.length // touch property for tracking
       return exists
     },
     set(key: K, value: V) {

--- a/src/vanilla/utils/proxyMap.ts
+++ b/src/vanilla/utils/proxyMap.ts
@@ -91,7 +91,7 @@ export function proxyMap<K, V>(entries?: Iterable<[K, V]> | undefined | null) {
       const map = getMapForThis(this)
       const exists = map.has(key)
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      this.epoch
+      this.epoch // touch property for tracking
       return map.has(key)
     },
     set(key: K, value: V) {

--- a/src/vanilla/utils/proxyMap.ts
+++ b/src/vanilla/utils/proxyMap.ts
@@ -6,6 +6,7 @@ const isProxy = (x: any) => proxyStateMap.has(x)
 type InternalProxyObject<K, V> = Map<K, V> & {
   data: Array<V>
   index: number
+  epoch: number
   toJSON: () => Map<K, V>
 }
 
@@ -68,6 +69,7 @@ export function proxyMap<K, V>(entries?: Iterable<[K, V]> | undefined | null) {
   const vObject: InternalProxyObject<K, V> = {
     data: initialData,
     index: initialIndex,
+    epoch: 0,
     get size() {
       if (!isProxy(this)) {
         registerSnapMap()
@@ -80,15 +82,16 @@ export function proxyMap<K, V>(entries?: Iterable<[K, V]> | undefined | null) {
       const index = map.get(key)
       if (index === undefined) {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        this.index // touch property for tracking
+        this.epoch // touch property for tracking
         return undefined
       }
       return this.data[index]
     },
     has(key: K) {
       const map = getMapForThis(this)
+      const exists = map.has(key)
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      this.data.length // touch property for tracking
+      this.epoch
       return map.has(key)
     },
     set(key: K, value: V) {
@@ -102,6 +105,7 @@ export function proxyMap<K, V>(entries?: Iterable<[K, V]> | undefined | null) {
       } else {
         this.data[index] = value
       }
+      this.epoch++
       return this
     },
     delete(key: K) {
@@ -114,6 +118,7 @@ export function proxyMap<K, V>(entries?: Iterable<[K, V]> | undefined | null) {
       }
       delete this.data[index]
       indexMap.delete(key)
+      this.epoch++
       return true
     },
     clear() {
@@ -122,6 +127,7 @@ export function proxyMap<K, V>(entries?: Iterable<[K, V]> | undefined | null) {
       }
       this.data.length = 0 // empty array
       this.index = 0
+      this.epoch++
       indexMap.clear()
     },
     forEach(cb: (value: V, key: K, map: Map<K, V>) => void) {
@@ -163,6 +169,7 @@ export function proxyMap<K, V>(entries?: Iterable<[K, V]> | undefined | null) {
   Object.defineProperties(proxiedObject, {
     size: { enumerable: false },
     index: { enumerable: false },
+    epoch: { enumerable: false },
     data: { enumerable: false },
     toJSON: { enumerable: false },
   })

--- a/src/vanilla/utils/proxySet.ts
+++ b/src/vanilla/utils/proxySet.ts
@@ -73,10 +73,8 @@ export function proxySet<T>(initialValues?: Iterable<T> | null) {
       const map = getMapForThis(this)
       const v = maybeProxify(value)
       const exists = map.has(v)
-      if (!exists) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        this.index // touch property for tracking
-      }
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      this.data.length // touch property for tracking
       return exists
     },
     add(value: T) {

--- a/src/vanilla/utils/proxySet.ts
+++ b/src/vanilla/utils/proxySet.ts
@@ -72,10 +72,9 @@ export function proxySet<T>(initialValues?: Iterable<T> | null) {
     has(value: T) {
       const map = getMapForThis(this)
       const v = maybeProxify(value)
-      const exists = map.has(v)
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       this.data.length // touch property for tracking
-      return exists
+      return map.has(v)
     },
     add(value: T) {
       if (!isProxy(this)) {

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -385,7 +385,7 @@ describe('ui updates - useSnapshot', async () => {
 
       return (
         <>
-          <p>has key1: {`${snap.has('key')}`}</p>
+          <p>has key: {`${snap.has('key')}`}</p>
           <button onClick={() => state.set('key', 'value')}>set key</button>
           <button onClick={() => state.delete('key')}>delete key</button>
         </>
@@ -399,7 +399,7 @@ describe('ui updates - useSnapshot', async () => {
     )
 
     await waitFor(() => {
-      getByText('has key1: false')
+      getByText('has key: false')
     })
 
     fireEvent.click(getByText('set key'))

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -378,7 +378,7 @@ describe('snapshot', () => {
 })
 
 describe('ui updates - useSnapshot', async () => {
-  it('should update ui when calling has before and after deleting a key', async () => {
+  it('should update ui when calling has before and after setting and deleting a key', async () => {
     const state = proxyMap()
     const TestComponent = () => {
       const snap = useSnapshot(state)
@@ -410,6 +410,59 @@ describe('ui updates - useSnapshot', async () => {
     fireEvent.click(getByText('delete key'))
     await waitFor(() => {
       getByText('has key: false')
+    })
+  })
+
+  it('should update ui when calling has before and after settiing and deleting multiple keys', async () => {
+    const state = proxyMap()
+    const TestComponent = () => {
+      const snap = useSnapshot(state)
+
+      return (
+        <>
+          <p>has key: {`${snap.has('key')}`}</p>
+          <p>has key2: {`${snap.has('key2')}`}</p>
+          <button
+            onClick={() => {
+              state.set('key', 'value')
+              state.set('key2', 'value')
+            }}
+          >
+            set keys
+          </button>
+          <button
+            onClick={() => {
+              state.delete('key')
+              state.delete('key2')
+            }}
+          >
+            delete keys
+          </button>
+        </>
+      )
+    }
+
+    const { getByText } = render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      getByText('has key: false')
+      getByText('has key2: false')
+    })
+
+    fireEvent.click(getByText('set keys'))
+    await waitFor(() => {
+      getByText('has key: true')
+      getByText('has key2: true')
+    })
+
+    fireEvent.click(getByText('delete keys'))
+    await waitFor(() => {
+      getByText('has key: false')
+      getByText('has key2: false')
     })
   })
 })

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -319,6 +319,7 @@ describe('proxyMap internal', () => {
     ).toBe(false)
   })
 })
+
 describe('snapshot', () => {
   it('should error when trying to mutate a snapshot', () => {
     const state = proxyMap()
@@ -373,5 +374,42 @@ describe('snapshot', () => {
     const snap2 = snapshot(state)
     expect(snap1.get('key1')).toBe('val1')
     expect(snap2.get('key1')).toBe('val1modified')
+  })
+})
+
+describe('ui updates - useSnapshot', async () => {
+  it('should update ui when calling has before and after deleting a key', async () => {
+    const state = proxyMap()
+    const TestComponent = () => {
+      const snap = useSnapshot(state)
+
+      return (
+        <>
+          <p>has key1: {`${snap.has('key')}`}</p>
+          <button onClick={() => state.set('key', 'value')}>set key</button>
+          <button onClick={() => state.delete('key')}>delete key</button>
+        </>
+      )
+    }
+
+    const { getByText } = render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      getByText('has key1: false')
+    })
+
+    fireEvent.click(getByText('set key'))
+    await waitFor(() => {
+      getByText('has key: true')
+    })
+
+    fireEvent.click(getByText('delete key'))
+    await waitFor(() => {
+      getByText('has key: false')
+    })
   })
 })

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -465,4 +465,56 @@ describe('ui updates - useSnapshot', async () => {
       getByText('has key2: false')
     })
   })
+
+  it('should update ui when clearing the map', async () => {
+    const state = proxyMap()
+    const TestComponent = () => {
+      const snap = useSnapshot(state)
+
+      return (
+        <>
+          <p>has key: {`${snap.has('key')}`}</p>
+          <p>has key2: {`${snap.has('key2')}`}</p>
+          <button
+            onClick={() => {
+              state.set('key', 'value')
+              state.set('key2', 'value')
+            }}
+          >
+            set keys
+          </button>
+          <button
+            onClick={() => {
+              state.clear()
+            }}
+          >
+            clear map
+          </button>
+        </>
+      )
+    }
+
+    const { getByText } = render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      getByText('has key: false')
+      getByText('has key2: false')
+    })
+
+    fireEvent.click(getByText('set keys'))
+    await waitFor(() => {
+      getByText('has key: true')
+      getByText('has key2: true')
+    })
+
+    fireEvent.click(getByText('clear map'))
+    await waitFor(() => {
+      getByText('has key: false')
+      getByText('has key2: false')
+    })
+  })
 })

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -466,6 +466,110 @@ describe('ui updates - useSnapshot', async () => {
     })
   })
 
+  it('should update ui when calling has before and after settiing multile keys and deleting a single one (first item)', async () => {
+    const state = proxyMap()
+    const TestComponent = () => {
+      const snap = useSnapshot(state)
+
+      return (
+        <>
+          <p>has key: {`${snap.has('key')}`}</p>
+          <p>has key2: {`${snap.has('key2')}`}</p>
+          <button
+            onClick={() => {
+              state.set('key', 'value')
+              state.set('key2', 'value')
+            }}
+          >
+            set keys
+          </button>
+          <button
+            onClick={() => {
+              state.delete('key')
+            }}
+          >
+            delete keys
+          </button>
+        </>
+      )
+    }
+
+    const { getByText } = render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      getByText('has key: false')
+      getByText('has key2: false')
+    })
+
+    fireEvent.click(getByText('set keys'))
+    await waitFor(() => {
+      getByText('has key: true')
+      getByText('has key2: true')
+    })
+
+    fireEvent.click(getByText('delete keys'))
+    await waitFor(() => {
+      getByText('has key: false')
+      getByText('has key2: true')
+    })
+  })
+
+  it('should update ui when calling has before and after settiing multile keys and deleting a single one (first item)', async () => {
+    const state = proxyMap()
+    const TestComponent = () => {
+      const snap = useSnapshot(state)
+
+      return (
+        <>
+          <p>has key: {`${snap.has('key')}`}</p>
+          <p>has key2: {`${snap.has('key2')}`}</p>
+          <button
+            onClick={() => {
+              state.set('key', 'value')
+              state.set('key2', 'value')
+            }}
+          >
+            set keys
+          </button>
+          <button
+            onClick={() => {
+              state.delete('key2')
+            }}
+          >
+            delete keys
+          </button>
+        </>
+      )
+    }
+
+    const { getByText } = render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      getByText('has key: false')
+      getByText('has key2: false')
+    })
+
+    fireEvent.click(getByText('set keys'))
+    await waitFor(() => {
+      getByText('has key: true')
+      getByText('has key2: true')
+    })
+
+    fireEvent.click(getByText('delete keys'))
+    await waitFor(() => {
+      getByText('has key: true')
+      getByText('has key2: false')
+    })
+  })
+
   it('should update ui when clearing the map', async () => {
     const state = proxyMap()
     const TestComponent = () => {

--- a/tests/proxySet.test.tsx
+++ b/tests/proxySet.test.tsx
@@ -462,6 +462,110 @@ describe('ui updates - useSnapshot', async () => {
     })
   })
 
+  it('should update ui when calling has before and after settiing multiple values and deleting a single one (first item)', async () => {
+    const state = proxySet()
+    const TestComponent = () => {
+      const snap = useSnapshot(state)
+
+      return (
+        <>
+          <p>has value: {`${snap.has('value')}`}</p>
+          <p>has value2: {`${snap.has('value2')}`}</p>
+          <button
+            onClick={() => {
+              state.add('value')
+              state.add('value2')
+            }}
+          >
+            add values
+          </button>
+          <button
+            onClick={() => {
+              state.delete('value')
+            }}
+          >
+            delete values
+          </button>
+        </>
+      )
+    }
+
+    const { getByText } = render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      getByText('has value: false')
+      getByText('has value2: false')
+    })
+
+    fireEvent.click(getByText('add values'))
+    await waitFor(() => {
+      getByText('has value: true')
+      getByText('has value2: true')
+    })
+
+    fireEvent.click(getByText('delete values'))
+    await waitFor(() => {
+      getByText('has value: false')
+      getByText('has value2: true')
+    })
+  })
+
+  it('should update ui when calling has before and after settiing multiple values and deleting a single one (second item)', async () => {
+    const state = proxySet()
+    const TestComponent = () => {
+      const snap = useSnapshot(state)
+
+      return (
+        <>
+          <p>has value: {`${snap.has('value')}`}</p>
+          <p>has value2: {`${snap.has('value2')}`}</p>
+          <button
+            onClick={() => {
+              state.add('value')
+              state.add('value2')
+            }}
+          >
+            add values
+          </button>
+          <button
+            onClick={() => {
+              state.delete('value2')
+            }}
+          >
+            delete values
+          </button>
+        </>
+      )
+    }
+
+    const { getByText } = render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      getByText('has value: false')
+      getByText('has value2: false')
+    })
+
+    fireEvent.click(getByText('add values'))
+    await waitFor(() => {
+      getByText('has value: true')
+      getByText('has value2: true')
+    })
+
+    fireEvent.click(getByText('delete values'))
+    await waitFor(() => {
+      getByText('has value: true')
+      getByText('has value2: false')
+    })
+  })
+
   it('should update ui when clearing the set', async () => {
     const state = proxySet()
     const TestComponent = () => {

--- a/tests/proxySet.test.tsx
+++ b/tests/proxySet.test.tsx
@@ -367,7 +367,7 @@ describe('snapshot behavior', () => {
 })
 
 describe('ui updates - useSnapshot', async () => {
-  it('should update ui when calling has before and after deleting a value', async () => {
+  it('should update ui when calling has before and after setting anddeleting a value', async () => {
     const state = proxySet()
     const TestComponent = () => {
       const snap = useSnapshot(state)
@@ -375,7 +375,14 @@ describe('ui updates - useSnapshot', async () => {
       return (
         <>
           <p>has value: {`${snap.has('value')}`}</p>
-          <button onClick={() => state.add('value')}>add value</button>
+          <button
+            onClick={() => {
+              state.add('value')
+              state.add('value2')
+            }}
+          >
+            add value
+          </button>
           <button onClick={() => state.delete('value')}>delete value</button>
         </>
       )
@@ -399,6 +406,59 @@ describe('ui updates - useSnapshot', async () => {
     fireEvent.click(getByText('delete value'))
     await waitFor(() => {
       getByText('has value: false')
+    })
+  })
+
+  it('should update ui when calling has before and after settiing and deleting multiple values', async () => {
+    const state = proxySet()
+    const TestComponent = () => {
+      const snap = useSnapshot(state)
+
+      return (
+        <>
+          <p>has value: {`${snap.has('value')}`}</p>
+          <p>has value2: {`${snap.has('value2')}`}</p>
+          <button
+            onClick={() => {
+              state.add('value')
+              state.add('value2')
+            }}
+          >
+            add values
+          </button>
+          <button
+            onClick={() => {
+              state.delete('value')
+              state.delete('value2')
+            }}
+          >
+            delete values
+          </button>
+        </>
+      )
+    }
+
+    const { getByText } = render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      getByText('has value: false')
+      getByText('has value2: false')
+    })
+
+    fireEvent.click(getByText('add values'))
+    await waitFor(() => {
+      getByText('has value: true')
+      getByText('has value2: true')
+    })
+
+    fireEvent.click(getByText('delete values'))
+    await waitFor(() => {
+      getByText('has value: false')
+      getByText('has value2: false')
     })
   })
 })

--- a/tests/proxySet.test.tsx
+++ b/tests/proxySet.test.tsx
@@ -365,3 +365,40 @@ describe('snapshot behavior', () => {
     expect(snap2.has('val2')).toBe(true)
   })
 })
+
+describe('ui updates - useSnapshot', async () => {
+  it('should update ui when calling has before and after deleting a value', async () => {
+    const state = proxySet()
+    const TestComponent = () => {
+      const snap = useSnapshot(state)
+
+      return (
+        <>
+          <p>has value: {`${snap.has('value')}`}</p>
+          <button onClick={() => state.add('value')}>add value</button>
+          <button onClick={() => state.delete('value')}>delete value</button>
+        </>
+      )
+    }
+
+    const { getByText } = render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      getByText('has value: false')
+    })
+
+    fireEvent.click(getByText('add value'))
+    await waitFor(() => {
+      getByText('has value: true')
+    })
+
+    fireEvent.click(getByText('delete value'))
+    await waitFor(() => {
+      getByText('has value: false')
+    })
+  })
+})

--- a/tests/proxySet.test.tsx
+++ b/tests/proxySet.test.tsx
@@ -461,4 +461,56 @@ describe('ui updates - useSnapshot', async () => {
       getByText('has value2: false')
     })
   })
+
+  it('should update ui when clearing the set', async () => {
+    const state = proxySet()
+    const TestComponent = () => {
+      const snap = useSnapshot(state)
+
+      return (
+        <>
+          <p>has value: {`${snap.has('value')}`}</p>
+          <p>has value2: {`${snap.has('value2')}`}</p>
+          <button
+            onClick={() => {
+              state.add('value')
+              state.add('value2')
+            }}
+          >
+            add values
+          </button>
+          <button
+            onClick={() => {
+              state.clear()
+            }}
+          >
+            clear set
+          </button>
+        </>
+      )
+    }
+
+    const { getByText } = render(
+      <StrictMode>
+        <TestComponent />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      getByText('has value: false')
+      getByText('has value2: false')
+    })
+
+    fireEvent.click(getByText('add values'))
+    await waitFor(() => {
+      getByText('has value: true')
+      getByText('has value2: true')
+    })
+
+    fireEvent.click(getByText('clear set'))
+    await waitFor(() => {
+      getByText('has value: false')
+      getByText('has value2: false')
+    })
+  })
 })


### PR DESCRIPTION
…leared

## Related Bug Reports or Discussions
#979
Fixes #
#979 
## Summary
Accessing this.index in the has method doesn't seem to work when a new item is added and then deleted (or cleared) at a later time. Accessing the this.data.length property fixes this issue.


## Check List

- [ x ] `pnpm run prettier` for formatting code and docs
