### PR TITLE
test: use screen exposed by React Testing Library

### DIFF
--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -1,7 +1,7 @@
 /// <reference types="react/canary" />
 
 import ReactExports, { StrictMode, Suspense } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { it } from 'vitest'
 import { proxy, useSnapshot } from 'valtio'
 
@@ -30,7 +30,7 @@ it.skipIf(typeof use === 'undefined')('delayed increment', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Suspense fallback="loading">
         <Counter />
@@ -38,11 +38,11 @@ it.skipIf(typeof use === 'undefined')('delayed increment', async () => {
     </StrictMode>,
   )
 
-  await findByText('count: 0')
+  await screen.findByText('count: 0')
 
-  fireEvent.click(getByText('button'))
-  await findByText('loading')
-  await findByText('count: 1')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('loading')
+  await screen.findByText('count: 1')
 })
 
 it.skipIf(typeof use === 'undefined')('delayed object', async () => {
@@ -61,7 +61,7 @@ it.skipIf(typeof use === 'undefined')('delayed object', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Suspense fallback="loading">
         <Counter />
@@ -69,11 +69,11 @@ it.skipIf(typeof use === 'undefined')('delayed object', async () => {
     </StrictMode>,
   )
 
-  await findByText('text: none')
+  await screen.findByText('text: none')
 
-  fireEvent.click(getByText('button'))
-  await findByText('loading')
-  await findByText('text: hello')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('loading')
+  await screen.findByText('text: hello')
 })
 
 it.skipIf(typeof use === 'undefined')(
@@ -99,7 +99,7 @@ it.skipIf(typeof use === 'undefined')(
       )
     }
 
-    const { getByText, findByText } = render(
+    render(
       <StrictMode>
         <Suspense fallback="loading">
           <Counter />
@@ -107,18 +107,18 @@ it.skipIf(typeof use === 'undefined')(
       </StrictMode>,
     )
 
-    await findByText('loading')
+    await screen.findByText('loading')
     await waitFor(() => {
-      getByText('text: counter')
-      getByText('count: 0')
+      screen.getByText('text: counter')
+      screen.getByText('count: 0')
     })
 
-    fireEvent.click(getByText('button'))
+    fireEvent.click(screen.getByText('button'))
 
-    await findByText('loading')
+    await screen.findByText('loading')
     await waitFor(() => {
-      getByText('text: counter')
-      getByText('count: 1')
+      screen.getByText('text: counter')
+      screen.getByText('count: 1')
     })
   },
 )
@@ -139,7 +139,7 @@ it.skipIf(typeof use === 'undefined')('delayed falsy value', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Suspense fallback="loading">
         <Counter />
@@ -147,9 +147,9 @@ it.skipIf(typeof use === 'undefined')('delayed falsy value', async () => {
     </StrictMode>,
   )
 
-  await findByText('value: true')
+  await screen.findByText('value: true')
 
-  fireEvent.click(getByText('button'))
-  await findByText('loading')
-  await findByText('value: null')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('loading')
+  await screen.findByText('value: null')
 })

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode, useEffect, useRef, useState } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { expect, it, vi } from 'vitest'
 import { proxy, snapshot, useSnapshot } from 'valtio'
 
@@ -25,16 +25,16 @@ it('simple counter', async () => {
     )
   }
 
-  const { getByText, findByText, unmount } = render(
+  const { unmount } = render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('count: 0')
+  await screen.findByText('count: 0')
 
-  fireEvent.click(getByText('button'))
-  await findByText('count: 1')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: 1')
   unmount()
 })
 
@@ -65,7 +65,7 @@ it('no extra re-renders (commits)', async () => {
     )
   }
 
-  const { getByText } = render(
+  render(
     <>
       <Counter />
       <Counter2 />
@@ -73,20 +73,20 @@ it('no extra re-renders (commits)', async () => {
   )
 
   await waitFor(() => {
-    getByText('count: 0 (1)')
-    getByText('count2: 0 (1)')
+    screen.getByText('count: 0 (1)')
+    screen.getByText('count2: 0 (1)')
   })
 
-  fireEvent.click(getByText('button'))
+  fireEvent.click(screen.getByText('button'))
   await waitFor(() => {
-    getByText('count: 1 (2)')
-    getByText('count2: 0 (1)')
+    screen.getByText('count: 1 (2)')
+    screen.getByText('count2: 0 (1)')
   })
 
-  fireEvent.click(getByText('button2'))
+  fireEvent.click(screen.getByText('button2'))
   await waitFor(() => {
-    getByText('count: 1 (2)')
-    getByText('count2: 1 (2)')
+    screen.getByText('count: 1 (2)')
+    screen.getByText('count2: 1 (2)')
   })
 })
 
@@ -117,7 +117,7 @@ it('no extra re-renders (render func calls in non strict mode)', async () => {
     )
   }
 
-  const { getByText } = render(
+  render(
     <>
       <Counter />
       <Counter2 />
@@ -125,48 +125,48 @@ it('no extra re-renders (render func calls in non strict mode)', async () => {
   )
 
   await waitFor(() => {
-    getByText('count: 0')
-    getByText('count2: 0')
+    screen.getByText('count: 0')
+    screen.getByText('count2: 0')
   })
   expect(renderFn).toBeCalledTimes(1)
   expect(renderFn).lastCalledWith(0)
   expect(renderFn2).toBeCalledTimes(1)
   expect(renderFn2).lastCalledWith(0)
 
-  fireEvent.click(getByText('button'))
+  fireEvent.click(screen.getByText('button'))
   await waitFor(() => {
-    getByText('count: 1')
-    getByText('count2: 0')
+    screen.getByText('count: 1')
+    screen.getByText('count2: 0')
   })
   expect(renderFn).toBeCalledTimes(2)
   expect(renderFn).lastCalledWith(1)
   expect(renderFn2).toBeCalledTimes(1)
   expect(renderFn2).lastCalledWith(0)
 
-  fireEvent.click(getByText('button2'))
+  fireEvent.click(screen.getByText('button2'))
   await waitFor(() => {
-    getByText('count: 1')
-    getByText('count2: 1')
+    screen.getByText('count: 1')
+    screen.getByText('count2: 1')
   })
   expect(renderFn).toBeCalledTimes(2)
   expect(renderFn).lastCalledWith(1)
   expect(renderFn2).toBeCalledTimes(2)
   expect(renderFn2).lastCalledWith(1)
 
-  fireEvent.click(getByText('button2'))
+  fireEvent.click(screen.getByText('button2'))
   await waitFor(() => {
-    getByText('count: 1')
-    getByText('count2: 2')
+    screen.getByText('count: 1')
+    screen.getByText('count2: 2')
   })
   expect(renderFn).toBeCalledTimes(2)
   expect(renderFn).lastCalledWith(1)
   expect(renderFn2).toBeCalledTimes(3)
   expect(renderFn2).lastCalledWith(2)
 
-  fireEvent.click(getByText('button'))
+  fireEvent.click(screen.getByText('button'))
   await waitFor(() => {
-    getByText('count: 2')
-    getByText('count2: 2')
+    screen.getByText('count: 2')
+    screen.getByText('count2: 2')
   })
   expect(renderFn).toBeCalledTimes(3)
   expect(renderFn).lastCalledWith(2)
@@ -187,16 +187,16 @@ it('object in object', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('count: 0')
+  await screen.findByText('count: 0')
 
-  fireEvent.click(getByText('button'))
-  await findByText('count: 1')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: 1')
 })
 
 it('array in object', async () => {
@@ -214,16 +214,16 @@ it('array in object', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('counts: 0,1,2')
+  await screen.findByText('counts: 0,1,2')
 
-  fireEvent.click(getByText('button'))
-  await findByText('counts: 0,1,2,3')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('counts: 0,1,2,3')
 })
 
 it('array pop and splice', async () => {
@@ -240,19 +240,19 @@ it('array pop and splice', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('counts: 0,1,2')
+  await screen.findByText('counts: 0,1,2')
 
-  fireEvent.click(getByText('button'))
-  await findByText('counts: 0,1')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('counts: 0,1')
 
-  fireEvent.click(getByText('button2'))
-  await findByText('counts: 0,10,11,1')
+  fireEvent.click(screen.getByText('button2'))
+  await screen.findByText('counts: 0,10,11,1')
 })
 
 it('array length after direct assignment', async () => {
@@ -280,19 +280,19 @@ it('array length after direct assignment', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('counts: 0,1,2')
+  await screen.findByText('counts: 0,1,2')
 
-  fireEvent.click(getByText('increment'))
-  await findByText('counts: 0,1,2,3')
+  fireEvent.click(screen.getByText('increment'))
+  await screen.findByText('counts: 0,1,2,3')
 
-  fireEvent.click(getByText('jump'))
-  await findByText('counts: 0,1,2,3,,,,,,9')
+  fireEvent.click(screen.getByText('jump'))
+  await screen.findByText('counts: 0,1,2,3,,,,,,9')
 })
 
 it('deleting property', async () => {
@@ -308,16 +308,16 @@ it('deleting property', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('count: 1')
+  await screen.findByText('count: 1')
 
-  fireEvent.click(getByText('button'))
-  await findByText('count: none')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: none')
 })
 
 it('circular object', async () => {
@@ -335,16 +335,16 @@ it('circular object', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('count: 0')
+  await screen.findByText('count: 0')
 
-  fireEvent.click(getByText('button'))
-  await findByText('count: 1')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: 1')
 })
 
 it('circular object with non-proxy object (#375)', async () => {
@@ -357,13 +357,13 @@ it('circular object with non-proxy object (#375)', async () => {
     return <div>count: {snap.obj ? 1 : snap.count}</div>
   }
 
-  const { findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('count: 1')
+  await screen.findByText('count: 1')
 })
 
 it('render from outside', async () => {
@@ -385,17 +385,17 @@ it('render from outside', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('anotherCount: 0')
+  await screen.findByText('anotherCount: 0')
 
-  fireEvent.click(getByText('button'))
-  fireEvent.click(getByText('toggle'))
-  await findByText('count: 1')
+  fireEvent.click(screen.getByText('button'))
+  fireEvent.click(screen.getByText('toggle'))
+  await screen.findByText('count: 1')
 })
 
 it('counter with sync option', async () => {
@@ -413,19 +413,19 @@ it('counter with sync option', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <>
       <Counter />
     </>,
   )
 
-  await findByText('count: 0 (1)')
+  await screen.findByText('count: 0 (1)')
 
-  fireEvent.click(getByText('button'))
-  await findByText('count: 1 (2)')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: 1 (2)')
 
-  fireEvent.click(getByText('button'))
-  await findByText('count: 2 (3)')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: 2 (3)')
 })
 
 it('support undefined property (#439)', async () => {
@@ -438,13 +438,13 @@ it('support undefined property (#439)', async () => {
     return <div>has prop: {JSON.stringify('prop' in snap)}</div>
   }
 
-  const { findByText } = render(
+  render(
     <StrictMode>
       <Component />
     </StrictMode>,
   )
 
-  await findByText('has prop: true')
+  await screen.findByText('has prop: true')
 })
 
 it('sync snapshot between nested components (#460)', async () => {
@@ -475,21 +475,21 @@ it('sync snapshot between nested components (#460)', async () => {
     )
   }
 
-  const { getByText } = render(
+  render(
     <StrictMode>
       <Parent />
     </StrictMode>,
   )
 
   await waitFor(() => {
-    getByText('Parent: value1')
-    getByText('Child: value1')
+    screen.getByText('Parent: value1')
+    screen.getByText('Child: value1')
   })
 
-  fireEvent.click(getByText('button'))
+  fireEvent.click(screen.getByText('button'))
   await waitFor(() => {
-    getByText('Parent: value2')
-    getByText('Child: value2')
+    screen.getByText('Parent: value2')
+    screen.getByText('Child: value2')
   })
 })
 

--- a/tests/class.test.tsx
+++ b/tests/class.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode, useEffect, useRef } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { it } from 'vitest'
 import { proxy, useSnapshot } from 'valtio'
 
@@ -32,16 +32,16 @@ it('simple class without methods', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('count: 0')
+  await screen.findByText('count: 0')
 
-  fireEvent.click(getByText('button'))
-  await findByText('count: 1')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: 1')
 })
 
 it('no extra re-renders with class', async () => {
@@ -80,7 +80,7 @@ it('no extra re-renders with class', async () => {
     )
   }
 
-  const { getByText } = render(
+  render(
     <>
       <Counter />
       <Counter2 />
@@ -88,20 +88,20 @@ it('no extra re-renders with class', async () => {
   )
 
   await waitFor(() => {
-    getByText('count: 0 (0)')
-    getByText('count2: 0 (0)')
+    screen.getByText('count: 0 (0)')
+    screen.getByText('count2: 0 (0)')
   })
 
-  fireEvent.click(getByText('button'))
+  fireEvent.click(screen.getByText('button'))
   await waitFor(() => {
-    getByText('count: 1 (1)')
-    getByText('count2: 0 (0)')
+    screen.getByText('count: 1 (1)')
+    screen.getByText('count2: 0 (0)')
   })
 
-  fireEvent.click(getByText('button2'))
+  fireEvent.click(screen.getByText('button2'))
   await waitFor(() => {
-    getByText('count: 1 (1)')
-    getByText('count2: 1 (1)')
+    screen.getByText('count: 1 (1)')
+    screen.getByText('count2: 1 (1)')
   })
 })
 
@@ -132,16 +132,16 @@ it('inherited class without methods', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('count: 0')
+  await screen.findByText('count: 0')
 
-  fireEvent.click(getByText('button'))
-  await findByText('count: 1')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: 1')
 })
 
 it('class with a method', async () => {
@@ -178,7 +178,7 @@ it('class with a method', async () => {
     )
   }
 
-  const { getByText } = render(
+  render(
     <>
       <Counter />
       <Counter2 />
@@ -186,14 +186,14 @@ it('class with a method', async () => {
   )
 
   await waitFor(() => {
-    getByText('doubled: 0 (0)')
-    getByText('count: 0 (0)')
+    screen.getByText('doubled: 0 (0)')
+    screen.getByText('count: 0 (0)')
   })
 
-  fireEvent.click(getByText('button'))
+  fireEvent.click(screen.getByText('button'))
   await waitFor(() => {
-    getByText('doubled: 2 (1)')
-    getByText('count: 1 (1)')
+    screen.getByText('doubled: 2 (1)')
+    screen.getByText('count: 1 (1)')
   })
 })
 
@@ -241,7 +241,7 @@ it('inherited class with a method', async () => {
     )
   }
 
-  const { getByText } = render(
+  render(
     <>
       <Counter />
       <Counter2 />
@@ -249,20 +249,20 @@ it('inherited class with a method', async () => {
   )
 
   await waitFor(() => {
-    getByText('doubled: 0 (0)')
-    getByText('count2: 0 (0)')
+    screen.getByText('doubled: 0 (0)')
+    screen.getByText('count2: 0 (0)')
   })
 
-  fireEvent.click(getByText('button'))
+  fireEvent.click(screen.getByText('button'))
   await waitFor(() => {
-    getByText('doubled: 2 (1)')
-    getByText('count2: 0 (0)')
+    screen.getByText('doubled: 2 (1)')
+    screen.getByText('count2: 0 (0)')
   })
 
-  fireEvent.click(getByText('button2'))
+  fireEvent.click(screen.getByText('button2'))
   await waitFor(() => {
-    getByText('doubled: 2 (1)')
-    getByText('count2: 1 (1)')
+    screen.getByText('doubled: 2 (1)')
+    screen.getByText('count2: 1 (1)')
   })
 })
 
@@ -308,7 +308,7 @@ it('no extra re-renders with getters', async () => {
     )
   }
 
-  const { getByText } = render(
+  render(
     <>
       <Counter />
       <Counter2 />
@@ -316,19 +316,19 @@ it('no extra re-renders with getters', async () => {
   )
 
   await waitFor(() => {
-    getByText('count: 0 (0)')
-    getByText('sum: 0 (0)')
+    screen.getByText('count: 0 (0)')
+    screen.getByText('sum: 0 (0)')
   })
 
-  fireEvent.click(getByText('button'))
+  fireEvent.click(screen.getByText('button'))
   await waitFor(() => {
-    getByText('count: 1 (1)')
-    getByText('sum: 1 (1)')
+    screen.getByText('count: 1 (1)')
+    screen.getByText('sum: 1 (1)')
   })
 
-  fireEvent.click(getByText('button2'))
+  fireEvent.click(screen.getByText('button2'))
   await waitFor(() => {
-    getByText('count: 1 (1)')
-    getByText('sum: 2 (2)')
+    screen.getByText('count: 1 (1)')
+    screen.getByText('sum: 2 (2)')
   })
 })

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode, Suspense } from 'react'
-import { act, fireEvent, render } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { proxy, useSnapshot } from 'valtio'
 import { devtools } from 'valtio/utils'
@@ -163,18 +163,19 @@ it('updating state should call devtools.send', async () => {
   }
 
   extension.send.mockClear()
-  const { getByText, findByText } = render(
+
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
   expect(extension.send).toBeCalledTimes(0)
-  fireEvent.click(getByText('button'))
-  await findByText('count: 1')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: 1')
   expect(extension.send).toBeCalledTimes(1)
-  fireEvent.click(getByText('button'))
-  await findByText('count: 2')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: 2')
   expect(extension.send).toBeCalledTimes(2)
 })
 
@@ -194,7 +195,8 @@ describe('when it receives an message of type...', () => {
     }
 
     extension.send.mockClear()
-    const { getByText, findByText } = render(
+
+    render(
       <StrictMode>
         <Suspense fallback={'loading'}>
           <Counter />
@@ -203,8 +205,8 @@ describe('when it receives an message of type...', () => {
     )
 
     expect(extension.send).toBeCalledTimes(0)
-    fireEvent.click(getByText('button'))
-    await findByText('count: 1')
+    fireEvent.click(screen.getByText('button'))
+    await screen.findByText('count: 1')
     expect(extension.send).toBeCalledTimes(1)
     act(() =>
       (extensionSubscriber as (message: any) => void)({
@@ -212,7 +214,7 @@ describe('when it receives an message of type...', () => {
         payload: JSON.stringify({ count: 0 }),
       }),
     )
-    await findByText('count: 0')
+    await screen.findByText('count: 0')
     expect(extension.send).toBeCalledTimes(2)
   })
 
@@ -232,25 +234,26 @@ describe('when it receives an message of type...', () => {
       }
 
       extension.send.mockClear()
-      const { getByText, findByText } = render(
+
+      render(
         <StrictMode>
           <Counter />
         </StrictMode>,
       )
 
       expect(extension.send).toBeCalledTimes(0)
-      fireEvent.click(getByText('button'))
-      await findByText('count: 1')
+      fireEvent.click(screen.getByText('button'))
+      await screen.findByText('count: 1')
       expect(extension.send).toBeCalledTimes(1)
-      fireEvent.click(getByText('button'))
-      await findByText('count: 2')
+      fireEvent.click(screen.getByText('button'))
+      await screen.findByText('count: 2')
       act(() =>
         (extensionSubscriber as (message: any) => void)({
           type: 'DISPATCH',
           payload: { type: 'COMMIT' },
         }),
       )
-      await findByText('count: 2')
+      await screen.findByText('count: 2')
       expect(extension.init).toBeCalledWith({ count: 2 })
     })
 
@@ -269,7 +272,8 @@ describe('when it receives an message of type...', () => {
       }
 
       extension.send.mockClear()
-      const { getByText, findByText } = render(
+
+      render(
         <StrictMode>
           <Counter />
         </StrictMode>,
@@ -281,11 +285,11 @@ describe('when it receives an message of type...', () => {
       }
 
       expect(extension.send).toBeCalledTimes(0)
-      fireEvent.click(getByText('button'))
-      await findByText('count: 1')
+      fireEvent.click(screen.getByText('button'))
+      await screen.findByText('count: 1')
       expect(extension.send).toBeCalledTimes(1)
-      fireEvent.click(getByText('button'))
-      await findByText('count: 2')
+      fireEvent.click(screen.getByText('button'))
+      await screen.findByText('count: 2')
       act(() =>
         (extensionSubscriber as (message: any) => void)({
           type: 'DISPATCH',
@@ -293,7 +297,7 @@ describe('when it receives an message of type...', () => {
         }),
       )
       expect(extension.init).toBeCalledWith({ count: 5 })
-      await findByText('count: 6')
+      await screen.findByText('count: 6')
     })
 
     describe('JUMP_TO_STATE | JUMP_TO_ACTION...', () => {
@@ -312,15 +316,16 @@ describe('when it receives an message of type...', () => {
         }
 
         extension.send.mockClear()
-        const { getByText, findByText } = render(
+
+        render(
           <StrictMode>
             <Counter />
           </StrictMode>,
         )
 
         expect(extension.send).toBeCalledTimes(0)
-        fireEvent.click(getByText('button'))
-        await findByText('count: 1')
+        fireEvent.click(screen.getByText('button'))
+        await screen.findByText('count: 1')
         expect(extension.send).toBeCalledTimes(1)
         act(() =>
           (extensionSubscriber as (message: any) => void)({
@@ -329,12 +334,12 @@ describe('when it receives an message of type...', () => {
             state: JSON.stringify({ count: 0 }),
           }),
         )
-        await findByText('count: 0')
+        await screen.findByText('count: 0')
         expect(extension.send).toBeCalledTimes(1)
-        fireEvent.click(getByText('button'))
-        await findByText('count: 1')
-        fireEvent.click(getByText('button'))
-        await findByText('count: 2')
+        fireEvent.click(screen.getByText('button'))
+        await screen.findByText('count: 1')
+        fireEvent.click(screen.getByText('button'))
+        await screen.findByText('count: 2')
         expect(extension.send).toBeCalledTimes(3)
       })
     })

--- a/tests/getter.test.tsx
+++ b/tests/getter.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { expect, it, vi } from 'vitest'
 import { proxy, useSnapshot } from 'valtio'
 
@@ -24,7 +24,7 @@ it('simple object getters', async () => {
     )
   }
 
-  const { getByText } = render(
+  render(
     <StrictMode>
       <Counter name="A" />
       <Counter name="B" />
@@ -32,15 +32,15 @@ it('simple object getters', async () => {
   )
 
   await waitFor(() => {
-    getByText('A count: 0')
-    getByText('B count: 0')
+    screen.getByText('A count: 0')
+    screen.getByText('B count: 0')
   })
 
   computeDouble.mockClear()
-  fireEvent.click(getByText('A button'))
+  fireEvent.click(screen.getByText('A button'))
   await waitFor(() => {
-    getByText('A count: 2')
-    getByText('B count: 2')
+    screen.getByText('A count: 2')
+    screen.getByText('B count: 2')
   })
   expect(computeDouble).toBeCalledTimes(1)
 })
@@ -66,7 +66,7 @@ it('object getters returning object', async () => {
     )
   }
 
-  const { getByText } = render(
+  render(
     <StrictMode>
       <Counter name="A" />
       <Counter name="B" />
@@ -74,15 +74,15 @@ it('object getters returning object', async () => {
   )
 
   await waitFor(() => {
-    getByText('A count: 0')
-    getByText('B count: 0')
+    screen.getByText('A count: 0')
+    screen.getByText('B count: 0')
   })
 
   computeDouble.mockClear()
-  fireEvent.click(getByText('A button'))
+  fireEvent.click(screen.getByText('A button'))
   await waitFor(() => {
-    getByText('A count: 2')
-    getByText('B count: 2')
+    screen.getByText('A count: 2')
+    screen.getByText('B count: 2')
   })
   expect(computeDouble).toBeCalledTimes(1)
 })

--- a/tests/mapset.test.tsx
+++ b/tests/mapset.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { expect, it } from 'vitest'
 import { proxy, useSnapshot } from 'valtio'
 
@@ -16,17 +16,17 @@ it('unsupported map', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('count: 0')
+  await screen.findByText('count: 0')
 
-  fireEvent.click(getByText('button'))
+  fireEvent.click(screen.getByText('button'))
   await new Promise((resolve) => setTimeout(resolve, 10)) // FIXME better way?
-  expect(() => getByText('count: 1')).toThrow()
+  expect(() => screen.getByText('count: 1')).toThrow()
 })
 
 it('unsupported set', async () => {
@@ -42,15 +42,15 @@ it('unsupported set', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('count: 1,2,3')
+  await screen.findByText('count: 1,2,3')
 
-  fireEvent.click(getByText('button'))
+  fireEvent.click(screen.getByText('button'))
   await new Promise((resolve) => setTimeout(resolve, 10)) // FIXME better way?
-  expect(() => getByText('count: 1,2,3,4')).toThrow()
+  expect(() => screen.getByText('count: 1,2,3,4')).toThrow()
 })

--- a/tests/optimization.test.tsx
+++ b/tests/optimization.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { expect, it, vi } from 'vitest'
 import { proxy, useSnapshot } from 'valtio'
 
@@ -31,11 +31,11 @@ it('regression: useSnapshot renders should not fail consistency check with extra
     )
   }
 
-  const { getByText } = render(<Parent />)
+  render(<Parent />)
 
   await waitFor(() => {
-    getByText('childCount: 0')
-    getByText('parentCount: 0')
+    screen.getByText('childCount: 0')
+    screen.getByText('parentCount: 0')
   })
 
   expect(childRenderFn).toBeCalledTimes(1)
@@ -46,8 +46,8 @@ it('regression: useSnapshot renders should not fail consistency check with extra
   obj.parentCount += 1
 
   await waitFor(() => {
-    getByText('childCount: 0')
-    getByText('parentCount: 1')
+    screen.getByText('childCount: 0')
+    screen.getByText('parentCount: 1')
   })
 
   expect(childRenderFn).toBeCalledTimes(2)
@@ -88,11 +88,11 @@ it('regression: useSnapshot renders should not fail consistency check with extra
     )
   }
 
-  const { getByText } = render(<Parent />)
+  render(<Parent />)
 
   await waitFor(() => {
-    getByText('childCount: 0')
-    getByText('parentCount: 0')
+    screen.getByText('childCount: 0')
+    screen.getByText('parentCount: 0')
   })
 
   expect(childRenderFn).toBeCalledTimes(1)
@@ -102,11 +102,11 @@ it('regression: useSnapshot renders should not fail consistency check with extra
 
   obj.anotherValue += 1
 
-  fireEvent.click(getByText('parentButton'))
+  fireEvent.click(screen.getByText('parentButton'))
 
   await waitFor(() => {
-    getByText('childCount: 0')
-    getByText('parentCount: 1')
+    screen.getByText('childCount: 0')
+    screen.getByText('parentCount: 1')
   })
 
   expect(childRenderFn).toBeCalledTimes(2)

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { proxy, snapshot, useSnapshot } from 'valtio'
 import { proxyMap, proxySet } from 'valtio/utils'
@@ -205,18 +205,18 @@ describe('clear map', () => {
         )
       }
 
-      const { getByText } = render(
+      render(
         <StrictMode>
           <TestComponent />
         </StrictMode>,
       )
 
       expect(state.size).toBeGreaterThan(0)
-      getByText(`size: ${state.size}`)
+      screen.getByText(`size: ${state.size}`)
 
-      fireEvent.click(getByText('button'))
+      fireEvent.click(screen.getByText('button'))
       await waitFor(() => {
-        getByText('size: 0')
+        screen.getByText('size: 0')
       })
     })
   })
@@ -240,17 +240,17 @@ describe('add value', () => {
         )
       }
 
-      const { getByText } = render(
+      render(
         <StrictMode>
           <TestComponent />
         </StrictMode>,
       )
 
-      getByText('size: 0')
-      fireEvent.click(getByText('button'))
+      screen.getByText('size: 0')
+      fireEvent.click(screen.getByText('button'))
 
       await waitFor(() => {
-        getByText('size: 1')
+        screen.getByText('size: 1')
       })
     })
   })
@@ -288,20 +288,20 @@ describe('delete', () => {
         )
       }
 
-      const { getByText } = render(
+      render(
         <StrictMode>
           <TestComponent />
         </StrictMode>,
       )
 
-      getByText(`size: ${state.map.size}`)
+      screen.getByText(`size: ${state.map.size}`)
 
       const expectedSizeAfterDelete =
         state.map.size > 1 ? state.map.size - 1 : 0
 
-      fireEvent.click(getByText('button'))
+      fireEvent.click(screen.getByText('button'))
       await waitFor(() => {
-        getByText(`size: ${expectedSizeAfterDelete}`)
+        screen.getByText(`size: ${expectedSizeAfterDelete}`)
       })
     })
   })
@@ -392,24 +392,24 @@ describe('ui updates - useSnapshot', async () => {
       )
     }
 
-    const { getByText } = render(
+    render(
       <StrictMode>
         <TestComponent />
       </StrictMode>,
     )
 
     await waitFor(() => {
-      getByText('has key: false')
+      screen.getByText('has key: false')
     })
 
-    fireEvent.click(getByText('set key'))
+    fireEvent.click(screen.getByText('set key'))
     await waitFor(() => {
-      getByText('has key: true')
+      screen.getByText('has key: true')
     })
 
-    fireEvent.click(getByText('delete key'))
+    fireEvent.click(screen.getByText('delete key'))
     await waitFor(() => {
-      getByText('has key: false')
+      screen.getByText('has key: false')
     })
   })
 
@@ -442,27 +442,27 @@ describe('ui updates - useSnapshot', async () => {
       )
     }
 
-    const { getByText } = render(
+    render(
       <StrictMode>
         <TestComponent />
       </StrictMode>,
     )
 
     await waitFor(() => {
-      getByText('has key: false')
-      getByText('has key2: false')
+      screen.getByText('has key: false')
+      screen.getByText('has key2: false')
     })
 
-    fireEvent.click(getByText('set keys'))
+    fireEvent.click(screen.getByText('set keys'))
     await waitFor(() => {
-      getByText('has key: true')
-      getByText('has key2: true')
+      screen.getByText('has key: true')
+      screen.getByText('has key2: true')
     })
 
-    fireEvent.click(getByText('delete keys'))
+    fireEvent.click(screen.getByText('delete keys'))
     await waitFor(() => {
-      getByText('has key: false')
-      getByText('has key2: false')
+      screen.getByText('has key: false')
+      screen.getByText('has key2: false')
     })
   })
 
@@ -494,27 +494,27 @@ describe('ui updates - useSnapshot', async () => {
       )
     }
 
-    const { getByText } = render(
+    render(
       <StrictMode>
         <TestComponent />
       </StrictMode>,
     )
 
     await waitFor(() => {
-      getByText('has key: false')
-      getByText('has key2: false')
+      screen.getByText('has key: false')
+      screen.getByText('has key2: false')
     })
 
-    fireEvent.click(getByText('set keys'))
+    fireEvent.click(screen.getByText('set keys'))
     await waitFor(() => {
-      getByText('has key: true')
-      getByText('has key2: true')
+      screen.getByText('has key: true')
+      screen.getByText('has key2: true')
     })
 
-    fireEvent.click(getByText('delete keys'))
+    fireEvent.click(screen.getByText('delete keys'))
     await waitFor(() => {
-      getByText('has key: false')
-      getByText('has key2: true')
+      screen.getByText('has key: false')
+      screen.getByText('has key2: true')
     })
   })
 
@@ -546,27 +546,27 @@ describe('ui updates - useSnapshot', async () => {
       )
     }
 
-    const { getByText } = render(
+    render(
       <StrictMode>
         <TestComponent />
       </StrictMode>,
     )
 
     await waitFor(() => {
-      getByText('has key: false')
-      getByText('has key2: false')
+      screen.getByText('has key: false')
+      screen.getByText('has key2: false')
     })
 
-    fireEvent.click(getByText('set keys'))
+    fireEvent.click(screen.getByText('set keys'))
     await waitFor(() => {
-      getByText('has key: true')
-      getByText('has key2: true')
+      screen.getByText('has key: true')
+      screen.getByText('has key2: true')
     })
 
-    fireEvent.click(getByText('delete keys'))
+    fireEvent.click(screen.getByText('delete keys'))
     await waitFor(() => {
-      getByText('has key: true')
-      getByText('has key2: false')
+      screen.getByText('has key: true')
+      screen.getByText('has key2: false')
     })
   })
 
@@ -598,27 +598,27 @@ describe('ui updates - useSnapshot', async () => {
       )
     }
 
-    const { getByText } = render(
+    render(
       <StrictMode>
         <TestComponent />
       </StrictMode>,
     )
 
     await waitFor(() => {
-      getByText('has key: false')
-      getByText('has key2: false')
+      screen.getByText('has key: false')
+      screen.getByText('has key2: false')
     })
 
-    fireEvent.click(getByText('set keys'))
+    fireEvent.click(screen.getByText('set keys'))
     await waitFor(() => {
-      getByText('has key: true')
-      getByText('has key2: true')
+      screen.getByText('has key: true')
+      screen.getByText('has key2: true')
     })
 
-    fireEvent.click(getByText('clear map'))
+    fireEvent.click(screen.getByText('clear map'))
     await waitFor(() => {
-      getByText('has key: false')
-      getByText('has key2: false')
+      screen.getByText('has key: false')
+      screen.getByText('has key2: false')
     })
   })
 })

--- a/tests/proxySet.test.tsx
+++ b/tests/proxySet.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { proxy, snapshot, useSnapshot } from 'valtio'
 import { proxySet } from 'valtio/utils'
@@ -221,17 +221,17 @@ describe('clear set', () => {
         )
       }
 
-      const { getByText } = render(
+      render(
         <StrictMode>
           <TestComponent />
         </StrictMode>,
       )
 
-      getByText(`size: ${state.set.size}`)
+      screen.getByText(`size: ${state.set.size}`)
 
-      fireEvent.click(getByText('button'))
+      fireEvent.click(screen.getByText('button'))
       await waitFor(() => {
-        getByText('size: 0')
+        screen.getByText('size: 0')
       })
     })
   })
@@ -255,17 +255,17 @@ describe('add value', () => {
         )
       }
 
-      const { getByText } = render(
+      render(
         <StrictMode>
           <TestComponent />
         </StrictMode>,
       )
 
-      getByText('size: 0')
-      fireEvent.click(getByText('button'))
+      screen.getByText('size: 0')
+      fireEvent.click(screen.getByText('button'))
 
       await waitFor(() => {
-        getByText('size: 1')
+        screen.getByText('size: 1')
       })
     })
   })
@@ -296,20 +296,20 @@ describe('delete', () => {
         )
       }
 
-      const { getByText } = render(
+      render(
         <StrictMode>
           <TestComponent />
         </StrictMode>,
       )
 
-      getByText(`size: ${state.set.size}`)
+      screen.getByText(`size: ${state.set.size}`)
 
       const expectedSizeAfterDelete =
         state.set.size > 1 ? state.set.size - 1 : 0
 
-      fireEvent.click(getByText('button'))
+      fireEvent.click(screen.getByText('button'))
       await waitFor(() => {
-        getByText(`size: ${expectedSizeAfterDelete}`)
+        screen.getByText(`size: ${expectedSizeAfterDelete}`)
       })
     })
   })
@@ -388,24 +388,24 @@ describe('ui updates - useSnapshot', async () => {
       )
     }
 
-    const { getByText } = render(
+    render(
       <StrictMode>
         <TestComponent />
       </StrictMode>,
     )
 
     await waitFor(() => {
-      getByText('has value: false')
+      screen.getByText('has value: false')
     })
 
-    fireEvent.click(getByText('add value'))
+    fireEvent.click(screen.getByText('add value'))
     await waitFor(() => {
-      getByText('has value: true')
+      screen.getByText('has value: true')
     })
 
-    fireEvent.click(getByText('delete value'))
+    fireEvent.click(screen.getByText('delete value'))
     await waitFor(() => {
-      getByText('has value: false')
+      screen.getByText('has value: false')
     })
   })
 
@@ -438,27 +438,27 @@ describe('ui updates - useSnapshot', async () => {
       )
     }
 
-    const { getByText } = render(
+    render(
       <StrictMode>
         <TestComponent />
       </StrictMode>,
     )
 
     await waitFor(() => {
-      getByText('has value: false')
-      getByText('has value2: false')
+      screen.getByText('has value: false')
+      screen.getByText('has value2: false')
     })
 
-    fireEvent.click(getByText('add values'))
+    fireEvent.click(screen.getByText('add values'))
     await waitFor(() => {
-      getByText('has value: true')
-      getByText('has value2: true')
+      screen.getByText('has value: true')
+      screen.getByText('has value2: true')
     })
 
-    fireEvent.click(getByText('delete values'))
+    fireEvent.click(screen.getByText('delete values'))
     await waitFor(() => {
-      getByText('has value: false')
-      getByText('has value2: false')
+      screen.getByText('has value: false')
+      screen.getByText('has value2: false')
     })
   })
 
@@ -490,27 +490,27 @@ describe('ui updates - useSnapshot', async () => {
       )
     }
 
-    const { getByText } = render(
+    render(
       <StrictMode>
         <TestComponent />
       </StrictMode>,
     )
 
     await waitFor(() => {
-      getByText('has value: false')
-      getByText('has value2: false')
+      screen.getByText('has value: false')
+      screen.getByText('has value2: false')
     })
 
-    fireEvent.click(getByText('add values'))
+    fireEvent.click(screen.getByText('add values'))
     await waitFor(() => {
-      getByText('has value: true')
-      getByText('has value2: true')
+      screen.getByText('has value: true')
+      screen.getByText('has value2: true')
     })
 
-    fireEvent.click(getByText('delete values'))
+    fireEvent.click(screen.getByText('delete values'))
     await waitFor(() => {
-      getByText('has value: false')
-      getByText('has value2: true')
+      screen.getByText('has value: false')
+      screen.getByText('has value2: true')
     })
   })
 
@@ -542,27 +542,27 @@ describe('ui updates - useSnapshot', async () => {
       )
     }
 
-    const { getByText } = render(
+    render(
       <StrictMode>
         <TestComponent />
       </StrictMode>,
     )
 
     await waitFor(() => {
-      getByText('has value: false')
-      getByText('has value2: false')
+      screen.getByText('has value: false')
+      screen.getByText('has value2: false')
     })
 
-    fireEvent.click(getByText('add values'))
+    fireEvent.click(screen.getByText('add values'))
     await waitFor(() => {
-      getByText('has value: true')
-      getByText('has value2: true')
+      screen.getByText('has value: true')
+      screen.getByText('has value2: true')
     })
 
-    fireEvent.click(getByText('delete values'))
+    fireEvent.click(screen.getByText('delete values'))
     await waitFor(() => {
-      getByText('has value: true')
-      getByText('has value2: false')
+      screen.getByText('has value: true')
+      screen.getByText('has value2: false')
     })
   })
 
@@ -594,27 +594,27 @@ describe('ui updates - useSnapshot', async () => {
       )
     }
 
-    const { getByText } = render(
+    render(
       <StrictMode>
         <TestComponent />
       </StrictMode>,
     )
 
     await waitFor(() => {
-      getByText('has value: false')
-      getByText('has value2: false')
+      screen.getByText('has value: false')
+      screen.getByText('has value2: false')
     })
 
-    fireEvent.click(getByText('add values'))
+    fireEvent.click(screen.getByText('add values'))
     await waitFor(() => {
-      getByText('has value: true')
-      getByText('has value2: true')
+      screen.getByText('has value: true')
+      screen.getByText('has value2: true')
     })
 
-    fireEvent.click(getByText('clear set'))
+    fireEvent.click(screen.getByText('clear set'))
     await waitFor(() => {
-      getByText('has value: false')
-      getByText('has value2: false')
+      screen.getByText('has value: false')
+      screen.getByText('has value2: false')
     })
   })
 })

--- a/tests/ref.test.tsx
+++ b/tests/ref.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode, useEffect, useRef } from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { expect, it, vi } from 'vitest'
 import { proxy, ref, snapshot, subscribe, useSnapshot } from 'valtio'
 
@@ -27,16 +27,16 @@ it('should trigger re-render setting objects with ref wrapper', async () => {
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <>
       <Counter />
     </>,
   )
 
-  await findByText('count: 0 (1)')
+  await screen.findByText('count: 0 (1)')
 
-  fireEvent.click(getByText('button'))
-  await findByText('count: 0 (2)')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: 0 (2)')
 })
 
 it('should not track object wrapped in ref assigned to proxy state', async () => {
@@ -54,16 +54,16 @@ it('should not track object wrapped in ref assigned to proxy state', async () =>
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Component />
     </StrictMode>,
   )
 
-  await findByText('original')
+  await screen.findByText('original')
 
-  fireEvent.click(getByText('button'))
-  await findByText('replace')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('replace')
 })
 
 it('should not trigger re-render when mutating object wrapped in ref', async () => {
@@ -79,16 +79,16 @@ it('should not trigger re-render when mutating object wrapped in ref', async () 
     )
   }
 
-  const { getByText, findByText } = render(
+  render(
     <StrictMode>
       <Counter />
     </StrictMode>,
   )
 
-  await findByText('count: 0')
+  await screen.findByText('count: 0')
 
-  fireEvent.click(getByText('button'))
-  await findByText('count: 0')
+  fireEvent.click(screen.getByText('button'))
+  await screen.findByText('count: 0')
 })
 
 it('should not update snapshot or notify subscription when mutating proxy wrapped in ref', async () => {


### PR DESCRIPTION
## Summary

Tests using React Testing Library should use `screen` instead of queries methods returned by `render`.


## Check List

- [ x] `pnpm run prettier` for formatting code and docs