### PR TITLE
docs(*): change 'npm i' to 'npm install'

### DIFF
--- a/docs/introduction/getting-started.mdx
+++ b/docs/introduction/getting-started.mdx
@@ -14,7 +14,7 @@ The Valtio API is minimal, flexible, unopinionated and a touch magical. Valtio's
 #### Installation
 
 ```bash
-npm i valtio
+npm install valtio
 ```
 
 #### The to-do app example

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 <br />
 <br />
 
-<code>npm i valtio</code> makes proxy-state simple
+<code>npm install valtio</code> makes proxy-state simple
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/pmndrs/valtio/lint-and-type.yml?branch=main&style=flat&colorA=000000&colorB=000000)](https://github.com/pmndrs/valtio/actions?query=workflow%3ALint)
 [![Build Size](https://img.shields.io/bundlephobia/minzip/valtio?label=bundle%20size&style=flat&colorA=000000&colorB=000000)](https://bundlephobia.com/result?p=valtio)


### PR DESCRIPTION
## Summary

* Since this is an official document, I determined that using `npm install` instead of the abbreviation `npm i` is more appropriate, so I made the change.
* In the official homepage, both `npm install` and `npm i` are used, so I standardizied them.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
