### PR TITLE
Fixed `code` and `pre` elements to be styled correctly on both light and dark mode on valtio.dev

### DIFF
--- a/docs/api/advanced/subscribe.mdx
+++ b/docs/api/advanced/subscribe.mdx
@@ -5,7 +5,7 @@ subSection: 'Advanced'
 description: 'Subscribe to a current state/object'
 ---
 
-# subscribe
+# `subscribe`
 
 ## Subscribe from anywhere
 

--- a/website/styles/prism-theme.css
+++ b/website/styles/prism-theme.css
@@ -42,6 +42,10 @@ pre[class*="language-"] {
 
 code:not([class*="language-"]) {
   padding: 0.1em 0.3em;
+  background: #eee;
+}
+
+.dark code:not([class*="language-"]) {
   background: #2e3440;
 }
 


### PR DESCRIPTION
## Related Bug Reports or Discussions
Fixes #1031

## Summary

Fixed styles for light and dark mode on `code` and `pre` elements.

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
