### PR TITLE
fix: make `proxy` a no-op when passed a proxy

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -164,6 +164,9 @@ export function proxy<T extends object>(baseObject: T = {} as T): T {
   if (found) {
     return found
   }
+  if (proxyStateMap.has(baseObject)) {
+    return baseObject
+  }
   let version = versionHolder[0]
   const listeners = new Set<Listener>()
   const notifyUpdate = (op: Op, nextVersion = ++versionHolder[0]) => {


### PR DESCRIPTION
## Summary

As far as I can tell, there's no benefit to wrapping a Valtio proxy with `proxy(…)` but it can happen inadvertently. In this case, Valtio should simply return the proxy unchanged, since it's already subscribable.

In [valtio-kit](https://github.com/aleclarson/valtio-kit), I'm using `proxy(new Foo())` as a compiler hint, so the compiler can know to wrap references to the `Foo` instance with `get(…)` inside of `watch` handlers. In my testing of this compiler hint, I found this undesirable Valtio behavior of “proxying a proxy”.

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
