### PR TITLE
docs(class): change from `this` to `state`

### DIFF
--- a/docs/how-tos/how-to-organize-actions.mdx
+++ b/docs/how-tos/how-to-organize-actions.mdx
@@ -96,10 +96,10 @@ class State {
   count = 0
   name = 'foo'
   inc() {
-    ++this.count
+    ++state.count
   }
   setName(name) {
-    this.name = name
+    state.name = name
   }
 }
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A

## Summary

I think we have a typo or missing variable name in `how-to-organize-actions.mdx`. At current docs, the example uses the keyword `this` to refer to the store, but this doesn't work. If I change to use the `state` all things work properly. 

You can check here - https://codesandbox.io/p/sandbox/valtio-to-do-list-forked-yd8qmn?from-embed=&workspaceId=ws_3LPBn26rxpNUQF58gTv7g7

To test, change all occurrences of `this.` to `store.`

## Question

Is this an expected behaviour or a bug? If this is a bug, I can try to make a pull request fixing this.


## Check List

- [x] `pnpm run fix:format` for formatting code and docs
