### PR TITLE
docs: add `tauri-plugin-valtio` as a third-party library

### DIFF
--- a/docs/resources/libraries.mdx
+++ b/docs/resources/libraries.mdx
@@ -27,6 +27,8 @@ Disclaimer: These libraries may have bugs, limited maintenance, or other limitat
 
 - [swc-plugin-valtio](https://github.com/sosukesuzuki/swc-plugin-valtio) - Valtio useProxy transformer for SWC.
 
+- [tauri-plugin-valtio](https://github.com/ferreira-tb/tauri-store/tree/main/packages/tauri-plugin-valtio) - Persistent valtio state for Tauri, accessible from both JavaScript and Rust.
+
 - [use-valtio](https://github.com/dai-shi/use-valtio) - Another custom hook to use Valtio proxy state
 
 - [valtio-element](https://github.com/lxsmnsyc/valtio-element) - Create reactive, declarative custom elements with valtio


### PR DESCRIPTION
## Related Bug Reports or Discussions

## Summary

`tauri-plugin-valtio` is a Tauri plugin that provides a valtio integration. It can be used to save state to disk, share it across multiple windows, or even access it from the Rust backend.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
