### PR TITLE
chore: use github test reporter on CI and fix TS error

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -19,8 +19,10 @@ export default defineConfig({
       include: ['src/**/'],
       reporter: ['text', 'json', 'html', 'text-summary'],
       reportsDirectory: './coverage/',
+      provider: 'v8',
     },
     environment: 'jsdom',
     dir: 'tests',
+    reporters: process.env.GITHUB_ACTIONS ? ['default', 'github-actions'] : ['default'],
   },
 })


### PR DESCRIPTION
Fixes #

TS Error in vitest config. Coverage `provider` must be explicitly defined, otherwise produces TS error.
Also `Vitest` has nice [build-in Github reporter](https://vitest.dev/guide/reporters#github-actions-reporter).

- [x] `pnpm run fix` for formatting and linting code and docs
