### PR TITLE
docs(LICENSE): keep only the initial copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2023 Poimandres
+Copyright (c) 2020 Poimandres
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

* Same with https://github.com/pmndrs/jotai/pull/2999

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
