### PR TITLE
Expose listeners

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -43,6 +43,7 @@ type ProxyState = readonly [
   target: object,
   ensureVersion: (nextCheckVersion?: number) => number,
   addListener: AddListener,
+  listeners: Set<Listener>,
 ]
 
 const canProxyDefault = (x: unknown): boolean =>
@@ -251,7 +252,12 @@ export function proxy<T extends object>(baseObject: T = {} as T): T {
   )
   const proxyObject = newProxy(baseObject, handler)
   proxyCache.set(baseObject, proxyObject)
-  const proxyState: ProxyState = [baseObject, ensureVersion, addListener]
+  const proxyState: ProxyState = [
+    baseObject,
+    ensureVersion,
+    addListener,
+    listeners,
+  ]
   proxyStateMap.set(proxyObject, proxyState)
   Reflect.ownKeys(baseObject).forEach((key) => {
     const desc = Object.getOwnPropertyDescriptor(


### PR DESCRIPTION
## Summary

Exposing the internal listeners state via the proxyStateMap. This is for a case where we are using valtio-history with subscriptions at something other than the root. I'm hoping there's an easier way to do this. 

This is allowing us to solve this problem:

```ts
const state = proxy({
  numbers: [] as number[],
  sum: undefined as number | undefined,
});

subscribe(state.numbers, () => {
  state.sum = state.numbers.reduce((acc, n) => acc + n, 0);
}, true)

const history = proxyWithHistory(state);

history.value.numbers.push(1);
expect(history.value.sum).toBe(1);
await Promise.resolve(); // history snapshot

history.value.numbers.push(2);
expect(history.value.sum).toBe(3);
await Promise.resolve(); // history snapshot

history.undo();
expect(history.value.sum).toBe(1);
expect(history.value.numbers).toEqual([1]);

history.value.numbers.push(2);
expect(history.value.numbers).toEqual([1, 2]);
expect(history.value.sum).toBe(3); // <-- Fails
```

We have our own internal wrapper around proxyWithHistory to add some custom functionality (like allowing some state to trigger renders, but not be tracked in history, similar to refs). Maybe valtio-history doesn't need something like this as a core feature, but exposing the internal state allows us to handle it.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
