### PR TITLE
docs:fix build badge url 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <code>npm install valtio</code> makes proxy-state simple
 
-[![Build Status](https://img.shields.io/github/actions/workflow/status/pmndrs/valtio/lint-and-type.yml?branch=main&style=flat&colorA=000000&colorB=000000)](https://github.com/pmndrs/valtio/actions?query=workflow%3ALint)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/pmndrs/valtio/test.yml?branch=main&style=flat&colorA=000000&colorB=000000)](https://github.com/pmndrs/valtio/actions?query=workflow%3ALint)
 [![Build Size](https://img.shields.io/bundlephobia/minzip/valtio?label=bundle%20size&style=flat&colorA=000000&colorB=000000)](https://bundlephobia.com/result?p=valtio)
 [![Version](https://img.shields.io/npm/v/valtio?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/valtio)
 [![Downloads](https://img.shields.io/npm/dt/valtio.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/valtio)

--- a/examples/counter/src/prism.css
+++ b/examples/counter/src/prism.css
@@ -6,8 +6,8 @@
 code[class*='language-'],
 pre[class*='language-'] {
   color: #393a34;
-  font-family:
-    'Consolas', 'Bitstream Vera Sans Mono', 'Courier New', Courier, monospace;
+  font-family: 'Consolas', 'Bitstream Vera Sans Mono', 'Courier New', Courier,
+    monospace;
   direction: ltr;
   text-align: left;
   white-space: pre;

--- a/examples/todo/src/prism.css
+++ b/examples/todo/src/prism.css
@@ -6,8 +6,8 @@
 code[class*='language-'],
 pre[class*='language-'] {
   color: #393a34;
-  font-family:
-    'Consolas', 'Bitstream Vera Sans Mono', 'Courier New', Courier, monospace;
+  font-family: 'Consolas', 'Bitstream Vera Sans Mono', 'Courier New', Courier,
+    monospace;
   direction: ltr;
   text-align: left;
   white-space: pre;

--- a/website/styles/prism-theme.css
+++ b/website/styles/prism-theme.css
@@ -9,8 +9,8 @@ code[class*='language-'],
 pre[class*='language-'] {
   color: #f8f8f2;
   background: none;
-  font-family:
-    'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-family: 'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono',
+    monospace;
   text-align: left;
   white-space: pre;
   word-spacing: normal;
@@ -50,8 +50,8 @@ code:not([class*='language-']) {
 }
 
 code {
-  font-family:
-    'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-family: 'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono',
+    monospace;
 }
 
 code::before,


### PR DESCRIPTION
## Related Bug Reports or Discussions
1077
Fixes #
1077
## Summary
Changed the build badge url to a working one (test.yml) as the old one (type-and-lint.yml) no longer exists.
## Check List

- [x ] `pnpm run fix` for formatting and linting code and docs
