### PR TITLE
[Docs] Added a gotcha when importing in a non-react project

### DIFF
--- a/docs/how-tos/some-gotchas.mdx
+++ b/docs/how-tos/some-gotchas.mdx
@@ -228,18 +228,23 @@ Additionally, this issue involved not only updating devtools, but also triggerin
 ## Issue with imports when using a library other than `react` (i.e. solidjs)
 
 Valtio does not have to work within react, however it was built with react in mind. This being the case, the main `valtio` module exports the react modules alongside the vanilla modules for convenience. This can cause an error in Rollup that may look something like this:
+
 ```
  node_modules/.pnpm/valtio@2.1.4/node_modules/valtio/esm/react.mjs (2:18): "useRef" is not exported by "__vite-optional-peer-dep:react:valtio", imported by "node_modules/.pnpm/valtio@2.1.4/node_modules/valtio/esm/react.mjs".
- ```
- because the react modules being exported are expecting react and its hooks to be there.
+```
 
- There is a simple fix for this, however. Instead of importing this:
- ```ts
- import { proxy, snapshot, subscribe } from 'valtio'
- ```
- Instead, use the vanilla directory directly.
- ```ts
- import { proxy, snapshot, subsribe } from 'valtio/vanilla'
- // this also applies for the utils
- import { proxyMap, deepClone } from 'valtio/vanilla/utils'
- ```
+because the react modules being exported are expecting react and its hooks to be there.
+
+There is a simple fix for this, however. Instead of importing this:
+
+```ts
+import { proxy, snapshot, subscribe } from 'valtio'
+```
+
+Instead, use the vanilla directory directly.
+
+```ts
+import { proxy, snapshot, subsribe } from 'valtio/vanilla'
+// this also applies for the utils
+import { proxyMap, deepClone } from 'valtio/vanilla/utils'
+```

--- a/docs/how-tos/some-gotchas.mdx
+++ b/docs/how-tos/some-gotchas.mdx
@@ -241,7 +241,7 @@ There is a simple fix for this, however. Instead of importing from the main `val
 import { proxy, snapshot, subscribe } from 'valtio'
 ```
 
-you can import directly from the `vanilla` framework agnostic submodule:
+you can import directly from the framework-agnostic `vanilla` submodule:
 
 ```ts
 import { proxy, snapshot, subsribe } from 'valtio/vanilla'

--- a/docs/how-tos/some-gotchas.mdx
+++ b/docs/how-tos/some-gotchas.mdx
@@ -224,3 +224,22 @@ If the workaround is not applied and you are using react with [devtools()](https
 As a result, the devtools will not display any state change.
 
 Additionally, this issue involved not only updating devtools, but also triggering `re-render`.
+
+## Issue with imports when using a library other than `react` (i.e. solidjs)
+
+Valtio does not have to work within react, however it was built with react in mind. This being the case, the main `valtio` module exports the react modules alongside the vanilla modules for convenience. This can cause an error in Rollup that may look something like this:
+```
+ node_modules/.pnpm/valtio@2.1.4/node_modules/valtio/esm/react.mjs (2:18): "useRef" is not exported by "__vite-optional-peer-dep:react:valtio", imported by "node_modules/.pnpm/valtio@2.1.4/node_modules/valtio/esm/react.mjs".
+ ```
+ because the react modules being exported are expecting react and its hooks to be there.
+
+ There is a simple fix for this, however. Instead of importing this:
+ ```ts
+ import { proxy, snapshot, subscribe } from 'valtio'
+ ```
+ Instead, use the vanilla directory directly.
+ ```ts
+ import { proxy, snapshot, subsribe } from 'valtio/vanilla'
+ // this also applies for the utils
+ import { proxyMap, deepClone } from 'valtio/vanilla/utils'
+ ```

--- a/docs/how-tos/some-gotchas.mdx
+++ b/docs/how-tos/some-gotchas.mdx
@@ -227,21 +227,21 @@ Additionally, this issue involved not only updating devtools, but also triggerin
 
 ## Issue with imports when using a library other than `react` (i.e. solidjs)
 
-Valtio does not have to work within react, however it was built with react in mind. This being the case, the main `valtio` module exports the react modules alongside the vanilla modules for convenience. This can cause an error in Rollup that may look something like this:
+Valtio does not have to work within react, however it was built with react in mind. This being the case, the main `valtio` module exports the react modules alongside the vanilla modules for convenience. This means if you are attempting to import from the main `valtio` module or the `valtio/utils` submodule into a non-react project, you may end up with build errors like this:
 
 ```
  node_modules/.pnpm/valtio@2.1.4/node_modules/valtio/esm/react.mjs (2:18): "useRef" is not exported by "__vite-optional-peer-dep:react:valtio", imported by "node_modules/.pnpm/valtio@2.1.4/node_modules/valtio/esm/react.mjs".
 ```
 
-because the react modules being exported are expecting react and its hooks to be there.
+This occurs because the main valtio module exports both framework-agnostic and React-specific functionality, causing build tools like Rollup to look for React dependencies even when they're not needed.
 
-There is a simple fix for this, however. Instead of importing this:
+There is a simple fix for this, however. Instead of importing from the main `valtio` module like this:
 
 ```ts
 import { proxy, snapshot, subscribe } from 'valtio'
 ```
 
-Instead, use the vanilla directory directly.
+you can import directly from the `vanilla` framework agnostic submodule:
 
 ```ts
 import { proxy, snapshot, subsribe } from 'valtio/vanilla'


### PR DESCRIPTION
## Related Bug Reports or Discussions
#1088
Fixes #
#1088
## Summary
Since the main 'valtio' package exports react modules by default, it will throw an error during builds complaining that `React` isn't available. I suggested a simple fix of imported directly from the vanilla directory which fixes the issue.
## Check List

- [x ] `pnpm run fix` for formatting and linting code and docs
