### PR TITLE
chore(eslint): enforce file extension usage for internal modules, ignore external packages

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,7 +42,7 @@ export default tseslint.config(
       'import/namespace': 'off',
       'import/no-named-as-default-member': 'off',
       'import/no-duplicates': 'error',
-      'import/extensions': ['error', 'always'],
+      'import/extensions': ['error', 'always', { ignorePackages: true }],
       'import/order': [
         'error',
         {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,5 +1,4 @@
 import { resolve } from 'path'
-// eslint-disable-next-line import/extensions
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

* Same with https://github.com/pmndrs/zustand/pull/3116

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
