### PR TITLE
[docs] Added link to `valtio-auto-persist` library in docs

### DIFF
--- a/docs/resources/libraries.mdx
+++ b/docs/resources/libraries.mdx
@@ -35,7 +35,9 @@ Disclaimer: These libraries may have bugs, limited maintenance, or other limitat
 
 - [valtio-factory](https://github.com/mfellner/valtio-factory) - Create valtio state using the factory pattern
 
-- [valtio-persist](https://github.com/Noitidart/valtio-persist) - Flexible and performant saving of state to disk.
+- [valtio-fsm](https://github.com/valtiojs/valtio-fsm) - A a simple and chainable TypeScript-first finite state machine library powered by Valtio's reactivity system.
+
+- [valtio-persist](https://github.com/valtiojs/valtio-persist) - Flexible and performant saving of state to disk.
 
 - [valtio-reactive](https://github.com/valtiojs/valtio-reactive) - Valtio-reactive makes valtio a reactive library.
 

--- a/docs/resources/libraries.mdx
+++ b/docs/resources/libraries.mdx
@@ -39,6 +39,8 @@ Disclaimer: These libraries may have bugs, limited maintenance, or other limitat
 
 - [valtio-persist](https://github.com/valtiojs/valtio-persist) - Flexible and performant saving of state to disk.
 
+  - [valtio-auto-persist](https://github.com/valtiojs/valtio-auto-persist) - Experimental fork of valtio-persist that allows storing your state objects without the need for attaching a key to identify it. It uses [structure-id](https://github.com/overthemike/structure-id) behind the scenes.
+
 - [valtio-reactive](https://github.com/valtiojs/valtio-reactive) - Valtio-reactive makes valtio a reactive library.
 
 - [valtio-signal](https://github.com/dai-shi/valtio-signal) - Another React binding for Valtio proxy state


### PR DESCRIPTION
## Related Bug Reports or Discussions
N/A
Fixes #
N/A
## Summary
Added link for `valtio-auto-persist`
## Check List

- [x ] `pnpm run fix` for formatting and linting code and docs
