### PR TITLE
test(getter): switch to fake timers, replace 'waitFor' with 'vi.waitFor'

### DIFF
--- a/tests/getter.test.tsx
+++ b/tests/getter.test.tsx
@@ -1,7 +1,15 @@
 import { StrictMode } from 'react'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import { proxy, useSnapshot } from 'valtio'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 it('simple object getters', async () => {
   const computeDouble = vi.fn((x: number) => x * 2)
@@ -31,14 +39,14 @@ it('simple object getters', async () => {
     </StrictMode>,
   )
 
-  await waitFor(() => {
+  await vi.waitFor(() => {
     expect(screen.getByText('A count: 0')).toBeInTheDocument()
     expect(screen.getByText('B count: 0')).toBeInTheDocument()
   })
 
   computeDouble.mockClear()
   fireEvent.click(screen.getByText('A button'))
-  await waitFor(() => {
+  await vi.waitFor(() => {
     expect(screen.getByText('A count: 2')).toBeInTheDocument()
     expect(screen.getByText('B count: 2')).toBeInTheDocument()
   })
@@ -73,14 +81,14 @@ it('object getters returning object', async () => {
     </StrictMode>,
   )
 
-  await waitFor(() => {
+  await vi.waitFor(() => {
     expect(screen.getByText('A count: 0')).toBeInTheDocument()
     expect(screen.getByText('B count: 0')).toBeInTheDocument()
   })
 
   computeDouble.mockClear()
   fireEvent.click(screen.getByText('A button'))
-  await waitFor(() => {
+  await vi.waitFor(() => {
     expect(screen.getByText('A count: 2')).toBeInTheDocument()
     expect(screen.getByText('B count: 2')).toBeInTheDocument()
   })


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

* relate https://github.com/pmndrs/valtio/pull/1116#issuecomment-3050714059

## before

![image](https://github.com/user-attachments/assets/ced8d7f3-866c-4e02-9a07-57963510c54b)

## after

![image](https://github.com/user-attachments/assets/012b9f31-0484-4743-a67d-f2bcec670ec4)

`getter.test.tsx` has no error

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
