### PR TITLE
test(mapset): replace 'findByText' with 'getByText', and remove inline 'Promise' delay

### DIFF
--- a/tests/mapset.test.tsx
+++ b/tests/mapset.test.tsx
@@ -22,10 +22,9 @@ it('unsupported map', async () => {
     </StrictMode>,
   )
 
-  await screen.findByText('count: 0')
+  expect(screen.getByText('count: 0')).toBeInTheDocument()
 
   fireEvent.click(screen.getByText('button'))
-  await new Promise((resolve) => setTimeout(resolve, 10)) // FIXME better way?
   expect(() => screen.getByText('count: 1')).toThrow()
 })
 
@@ -48,9 +47,8 @@ it('unsupported set', async () => {
     </StrictMode>,
   )
 
-  await screen.findByText('count: 1,2,3')
+  expect(screen.getByText('count: 1,2,3')).toBeInTheDocument()
 
   fireEvent.click(screen.getByText('button'))
-  await new Promise((resolve) => setTimeout(resolve, 10)) // FIXME better way?
   expect(() => screen.getByText('count: 1,2,3,4')).toThrow()
 })


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

## before

<img width="824" alt="image" src="https://github.com/user-attachments/assets/9b53efc9-ad09-446b-b924-5b79b8635b86" />

## after

<img width="835" alt="image" src="https://github.com/user-attachments/assets/59657429-ac29-4bd0-8fe4-2857af5e9ee9" />

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
