### PR TITLE
test(subscribe): add 'expect' to should not cause infinite loop case

### DIFF
--- a/tests/subscribe.test.tsx
+++ b/tests/subscribe.test.tsx
@@ -90,16 +90,20 @@ describe('subscribe', () => {
 
   it('should not cause infinite loop', async () => {
     const obj = proxy({ count: 0 })
-    const handler = () => {
+    const handler = vi.fn(() => {
       // Reset count if above 5
       if (obj.count > 5) {
         obj.count = 0
       }
-    }
+    })
 
     subscribe(obj, handler)
 
     obj.count = 10
+
+    await Promise.resolve()
+    expect(handler).toBeCalledTimes(1)
+    expect(obj.count).toBe(0)
   })
 
   it('should batch updates', async () => {


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

* relate https://github.com/pmndrs/valtio/pull/1116#issuecomment-3050714059

## before

<img width="970" alt="image" src="https://github.com/user-attachments/assets/bec05d7c-58e3-4eb9-b5bb-dce84d785c6c" />


## after

<img width="965" alt="image" src="https://github.com/user-attachments/assets/f7ead241-3e6b-4a4f-8952-e3e9cd0340c7" />


## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
