### PR TITLE
test(watch): add 'expect' to should not infinite loop with sync case

### DIFF
--- a/tests/watch.test.tsx
+++ b/tests/watch.test.tsx
@@ -100,14 +100,20 @@ describe('watch', () => {
   it('should not loop infinitely with sync (#382)', () => {
     const reference = proxy({ value: 'Example' })
 
+    const callback = vi.fn()
+
     watch(
       (get) => {
         get(reference)
+        callback()
       },
       { sync: true },
     )
 
+    expect(callback).toBeCalledTimes(1)
     reference.value = 'Update'
+    expect(callback).toBeCalledTimes(2)
+    expect(reference.value).toBe('Update')
   })
   it('should support promise watchers', async () => {
     const reference = proxy({ value: 'Example' })


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

* relate https://github.com/pmndrs/valtio/pull/1116#issuecomment-3050714059

## before

<img width="968" alt="image" src="https://github.com/user-attachments/assets/12060ffd-3f05-4b2f-a228-953a4ed806ca" />

## after

<img width="965" alt="image" src="https://github.com/user-attachments/assets/a8f59450-b580-4a8c-b94a-6ee07f917985" />

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
