### PR TITLE
test(async): switch to fake timers, add 'vi.waitFor', and replace 'findByText' with 'getByText'

### DIFF
--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -119,7 +119,6 @@ it.skipIf(typeof use === 'undefined')(
       )
     }
 
-    // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(() =>
       render(
         <StrictMode>

--- a/tests/async.test.tsx
+++ b/tests/async.test.tsx
@@ -1,9 +1,17 @@
 /// <reference types="react/canary" />
 
 import ReactExports, { StrictMode, Suspense } from 'react'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { expect, it } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import { proxy, useSnapshot } from 'valtio'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 const sleep = (ms: number) =>
   new Promise((resolve) => {
@@ -39,11 +47,16 @@ it.skipIf(typeof use === 'undefined')('delayed increment', async () => {
     </StrictMode>,
   )
 
-  expect(await screen.findByText('count: 0')).toBeInTheDocument()
-
+  await vi.waitFor(() =>
+    expect(screen.getByText('count: 0')).toBeInTheDocument(),
+  )
   fireEvent.click(screen.getByText('button'))
-  expect(await screen.findByText('loading')).toBeInTheDocument()
-  expect(await screen.findByText('count: 1')).toBeInTheDocument()
+  await vi.waitFor(() =>
+    expect(screen.getByText('loading')).toBeInTheDocument(),
+  )
+  await vi.waitFor(() =>
+    expect(screen.getByText('count: 1')).toBeInTheDocument(),
+  )
 })
 
 it.skipIf(typeof use === 'undefined')('delayed object', async () => {
@@ -70,11 +83,17 @@ it.skipIf(typeof use === 'undefined')('delayed object', async () => {
     </StrictMode>,
   )
 
-  expect(await screen.findByText('text: none')).toBeInTheDocument()
+  await vi.waitFor(() =>
+    expect(screen.getByText('text: none')).toBeInTheDocument(),
+  )
 
   fireEvent.click(screen.getByText('button'))
-  expect(await screen.findByText('loading')).toBeInTheDocument()
-  expect(await screen.findByText('text: hello')).toBeInTheDocument()
+  await vi.waitFor(() =>
+    expect(screen.getByText('loading')).toBeInTheDocument(),
+  )
+  await vi.waitFor(() =>
+    expect(screen.getByText('text: hello')).toBeInTheDocument(),
+  )
 })
 
 it.skipIf(typeof use === 'undefined')(
@@ -100,26 +119,31 @@ it.skipIf(typeof use === 'undefined')(
       )
     }
 
-    await act(async () => {
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(() =>
       render(
         <StrictMode>
           <Suspense fallback="loading">
             <Counter />
           </Suspense>
         </StrictMode>,
-      )
-    })
+      ),
+    )
 
-    expect(await screen.findByText('loading')).toBeInTheDocument()
-    await waitFor(() => {
+    await vi.waitFor(() =>
+      expect(screen.getByText('loading')).toBeInTheDocument(),
+    )
+    await vi.waitFor(() => {
       expect(screen.getByText('text: counter')).toBeInTheDocument()
       expect(screen.getByText('count: 0')).toBeInTheDocument()
     })
 
     fireEvent.click(screen.getByText('button'))
 
-    expect(await screen.findByText('loading')).toBeInTheDocument()
-    await waitFor(() => {
+    await vi.waitFor(() =>
+      expect(screen.getByText('loading')).toBeInTheDocument(),
+    )
+    await vi.waitFor(() => {
       expect(screen.getByText('text: counter')).toBeInTheDocument()
       expect(screen.getByText('count: 1')).toBeInTheDocument()
     })
@@ -150,9 +174,15 @@ it.skipIf(typeof use === 'undefined')('delayed falsy value', async () => {
     </StrictMode>,
   )
 
-  expect(await screen.findByText('value: true')).toBeInTheDocument()
+  await vi.waitFor(() =>
+    expect(screen.getByText('value: true')).toBeInTheDocument(),
+  )
 
   fireEvent.click(screen.getByText('button'))
-  expect(await screen.findByText('loading')).toBeInTheDocument()
-  expect(await screen.findByText('value: null')).toBeInTheDocument()
+  await vi.waitFor(() =>
+    expect(screen.getByText('loading')).toBeInTheDocument(),
+  )
+  await vi.waitFor(() =>
+    expect(screen.getByText('value: null')).toBeInTheDocument(),
+  )
 })


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

* relate https://github.com/pmndrs/valtio/pull/1116#issuecomment-3050714059

## before

<img width="968" alt="image" src="https://github.com/user-attachments/assets/499029cd-c292-4215-8ca4-2f7e0d64acc8" />

## after

<img width="968" alt="image" src="https://github.com/user-attachments/assets/8887b963-7d6f-43cf-a086-c29ad3fe9d98" />

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
