### PR TITLE
fix(vanilla): snapshot should change with subscription after deleting nested props (ensureVersion() if listeners size zero)

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -200,7 +200,7 @@ export function proxy<T extends object>(baseObject: T = {} as T): T {
   }
   let checkVersion = versionHolder[1]
   const ensureVersion = (nextCheckVersion = ++versionHolder[1]) => {
-    if (checkVersion !== nextCheckVersion) {
+    if (checkVersion !== nextCheckVersion && !listeners.size) {
       checkVersion = nextCheckVersion
       propProxyStates.forEach(([propProxyState]) => {
         const propVersion = propProxyState[1](nextCheckVersion)

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -245,6 +245,9 @@ export function proxy<T extends object>(baseObject: T = {} as T): T {
     }
   }
   const addListener = (listener: Listener) => {
+    if (listeners.size === 0) {
+      ensureVersion()
+    }
     listeners.add(listener)
     if (listeners.size === 1) {
       propProxyStates.forEach(([propProxyState, prevRemove], prop) => {


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #1152

## Summary

Pre trying fix in #1153 cause performance issue.

Finally I come up with a simple solution:
we just need to `ensureVersion` when `listeners.size` condition changed, that is when `subscribe` or more precisely `addListener` being called.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
