### PR TITLE
chore: strict unused check

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,7 +72,7 @@ export default tseslint.config(
       ],
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': [
-        'warn',
+        'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
       'react-hooks/react-compiler': 'error',
@@ -95,7 +95,6 @@ export default tseslint.config(
     files: ['tests/**/*.{ts,tsx}'],
     rules: {
       'import/extensions': ['error', 'never'],
-      '@typescript-eslint/no-unused-vars': 'off',
       'vitest/consistent-test-it': [
         'error',
         { fn: 'it', withinDescribe: 'it' },

--- a/tests/proxyMap.bench.ts
+++ b/tests/proxyMap.bench.ts
@@ -63,8 +63,8 @@ TEST_SIZES.forEach((size) => {
     const testData = generateTestData(size)
 
     bench('proxyMap', () => {
-      const map = proxyMap<number, number>(testData)
-      testData.forEach(([key, value]) => {})
+      const _map = proxyMap<number, number>(testData)
+      testData.forEach(([_key, _value]) => {})
     })
   })
 
@@ -120,7 +120,7 @@ TEST_SIZES.forEach((size) => {
     bench('proxyMap', () => {
       const map = proxyMap<number, number>(testData)
       const snap = snapshot(map)
-      testData.forEach(([key, value]) => {
+      testData.forEach(([key, _value]) => {
         snap.get(key)
       })
     })
@@ -132,9 +132,9 @@ TEST_SIZES.forEach((size) => {
 
     bench('proxyMap', () => {
       const map = proxyMap<number, number>(testData)
-      const snap1 = snapshot(map)
+      const _snap1 = snapshot(map)
       map.set(oneData[0], oneData[1])
-      const snap2 = snapshot(map)
+      const _snap2 = snapshot(map)
     })
   })
 

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -624,7 +624,7 @@ describe('proxyMap', () => {
     it('should update ui when calling only one get with absent key added later', async () => {
       const state = proxyMap()
       const TestComponent = () => {
-        const snap = useSnapshot(state)
+        const _snap = useSnapshot(state)
 
         return (
           <>

--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -624,7 +624,8 @@ describe('proxyMap', () => {
     it('should update ui when calling only one get with absent key added later', async () => {
       const state = proxyMap()
       const TestComponent = () => {
-        const _snap = useSnapshot(state)
+        const snap = useSnapshot(state)
+        expect(snap).toBeDefined()
 
         return (
           <>

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -185,7 +185,7 @@ describe('snapshot', () => {
         }
       }
 
-      type A = Snapshot<typeof user>
+      type A = Snapshot<typeof _user>
       type B = {
         readonly firstName: string
         readonly lastName: string
@@ -193,7 +193,7 @@ describe('snapshot', () => {
         readonly hasRole: (role: string) => boolean
       }
 
-      const user = new User()
+      const _user = new User()
 
       expectTypeOf<A>().toEqualTypeOf<B>()
     })

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -185,7 +185,7 @@ describe('snapshot', () => {
         }
       }
 
-      type A = Snapshot<typeof _user>
+      type A = Snapshot<typeof user>
       type B = {
         readonly firstName: string
         readonly lastName: string
@@ -193,7 +193,8 @@ describe('snapshot', () => {
         readonly hasRole: (role: string) => boolean
       }
 
-      const _user = new User()
+      const user = new User()
+      expect(user).toBeDefined()
 
       expectTypeOf<A>().toEqualTypeOf<B>()
     })


### PR DESCRIPTION
I don't remember when I did "warn" instead of "error". Let's use `_` prefix for exceptions.