### PR TITLE
chore: upgrade pnpm to v10.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "url": "https://github.com/pmndrs/valtio/issues"
   },
   "homepage": "https://github.com/pmndrs/valtio",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@10.15.0",
   "dependencies": {
     "proxy-compare": "^3.0.1"
   },


### PR DESCRIPTION
## Related Bug Reports or Discussions

same with https://github.com/pmndrs/jotai/pull/3138

## Summary

Upgrade pnpm from v9.15.5 to v10.15.0 to stay up-to-date with latest stable version.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
