### PR TITLE
docs: add gotcha on controlled inputs and cursor position without `sync: true`

### DIFF
--- a/docs/how-tos/some-gotchas.mdx
+++ b/docs/how-tos/some-gotchas.mdx
@@ -148,6 +148,33 @@ subscribe(state.subscribeData, async () => {
 })
 ```
 
+## Controlled inputs may lose caret position without `sync: true`
+
+Ref: https://github.com/pmndrs/valtio/issues/270
+
+When using Valtio state with controlled `<input>` elements, you might notice the text caret jumping to the end while typing in the middle of the existing text.
+
+This happens because Valtio batches state updates causing React to re-render after the input event. React resets the DOM value and loses the caret position.
+
+**Use `{ sync: true }` to update synchronously and preserve the caret:**
+
+```jsx
+function Input() {
+  const snap = useSnapshot(state, { sync: true })
+
+  return (
+    <input
+      value={snap.text}
+      onChange={(e) => {
+        state.text = e.target.value
+      }}
+    />
+  )
+}
+```
+
+`sync: true` disables batching so React re-renders within the same event loop tick, skipping the DOM update and preserving the caret position.
+
 ## Issue with `array` `proxy`
 
 The following use case can occur unexpected results on `arr` subscription:


### PR DESCRIPTION
## Related Bug Reports or Discussions

Document #270 in the Valtio's [gotcha docs](https://valtio.dev/docs/how-tos/some-gotchas)

## Summary

This should be a common gotcha that is only documented in the repo's readme. Add a section in the actual docs

<img width="1131" height="672" alt="image" src="https://github.com/user-attachments/assets/ce159602-e488-4076-96d5-432c90ad948a" />



## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
