### PR TITLE
test(ssr): add SSR and hydration tests for 'getServerSnapshot'

### DIFF
--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, useEffect, useLayoutEffect, useState } from 'react'
 import { act, fireEvent, render, screen } from '@testing-library/react'
+import { renderToString } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { proxy, snapshot, useSnapshot } from 'valtio'
 import { useCommitCount } from './utils'
@@ -11,6 +12,24 @@ describe('basic', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('should return snapshot via getServerSnapshot with renderToString', () => {
+    const obj = proxy({ count: 0 })
+
+    const Counter = () => {
+      const snap = useSnapshot(obj)
+      return <div>count: {snap.count}</div>
+    }
+
+    const view = renderToString(
+      <StrictMode>
+        <Counter />
+      </StrictMode>,
+    )
+
+    expect(view).toContain('count:')
+    expect(view).toContain('0')
   })
 
   it('simple counter', async () => {

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,6 +1,5 @@
 import { StrictMode, useEffect, useLayoutEffect, useState } from 'react'
 import { act, fireEvent, render, screen } from '@testing-library/react'
-import { renderToString } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { proxy, snapshot, useSnapshot } from 'valtio'
 import { useCommitCount } from './utils'
@@ -12,24 +11,6 @@ describe('basic', () => {
 
   afterEach(() => {
     vi.useRealTimers()
-  })
-
-  it('should return snapshot via getServerSnapshot with renderToString', () => {
-    const obj = proxy({ count: 0 })
-
-    const Counter = () => {
-      const snap = useSnapshot(obj)
-      return <div>count: {snap.count}</div>
-    }
-
-    const view = renderToString(
-      <StrictMode>
-        <Counter />
-      </StrictMode>,
-    )
-
-    expect(view).toContain('count:')
-    expect(view).toContain('0')
   })
 
   it('simple counter', async () => {

--- a/tests/ssr.test.tsx
+++ b/tests/ssr.test.tsx
@@ -1,9 +1,15 @@
 import { StrictMode } from 'react'
+import { act } from '@testing-library/react'
+import { hydrateRoot } from 'react-dom/client'
 import { renderToString } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { proxy, useSnapshot } from 'valtio'
 
 describe('ssr', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
   it('should return initial snapshot in SSR', () => {
     const obj = proxy({ count: 0 })
 
@@ -40,5 +46,39 @@ describe('ssr', () => {
 
     expect(view).toContain('count:')
     expect(view).toContain('5')
+  })
+
+  it('should not cause hydration mismatch', async () => {
+    const obj = proxy({ count: 0 })
+
+    const Counter = () => {
+      const snap = useSnapshot(obj)
+      return <div>count: {snap.count}</div>
+    }
+
+    const view = renderToString(
+      <StrictMode>
+        <Counter />
+      </StrictMode>,
+    )
+
+    const container = document.createElement('div')
+    container.innerHTML = view
+    document.body.appendChild(container)
+
+    const errorSpy = vi.spyOn(console, 'error')
+
+    await act(() =>
+      hydrateRoot(
+        container,
+        <StrictMode>
+          <Counter />
+        </StrictMode>,
+      ),
+    )
+
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
   })
 })

--- a/tests/ssr.test.tsx
+++ b/tests/ssr.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { proxy, useSnapshot } from 'valtio'
 
 describe('ssr', () => {
-  it('should return snapshot via getServerSnapshot with renderToString', () => {
+  it('should return initial snapshot in SSR', () => {
     const obj = proxy({ count: 0 })
 
     const Counter = () => {
@@ -20,5 +20,25 @@ describe('ssr', () => {
 
     expect(view).toContain('count:')
     expect(view).toContain('0')
+  })
+
+  it('should return the latest snapshot after proxy state changes', () => {
+    const obj = proxy({ count: 0 })
+
+    obj.count = 5
+
+    const Counter = () => {
+      const snap = useSnapshot(obj)
+      return <div>count: {snap.count}</div>
+    }
+
+    const view = renderToString(
+      <StrictMode>
+        <Counter />
+      </StrictMode>,
+    )
+
+    expect(view).toContain('count:')
+    expect(view).toContain('5')
   })
 })

--- a/tests/ssr.test.tsx
+++ b/tests/ssr.test.tsx
@@ -1,0 +1,24 @@
+import { StrictMode } from 'react'
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { proxy, useSnapshot } from 'valtio'
+
+describe('ssr', () => {
+  it('should return snapshot via getServerSnapshot with renderToString', () => {
+    const obj = proxy({ count: 0 })
+
+    const Counter = () => {
+      const snap = useSnapshot(obj)
+      return <div>count: {snap.count}</div>
+    }
+
+    const view = renderToString(
+      <StrictMode>
+        <Counter />
+      </StrictMode>,
+    )
+
+    expect(view).toContain('count:')
+    expect(view).toContain('0')
+  })
+})


### PR DESCRIPTION
## Summary

- Add `ssr.test.tsx` with tests for `getServerSnapshot` callback in `useSnapshot`
- Test initial snapshot and latest snapshot after proxy state changes
- Add hydration mismatch test to verify `getServerSnapshot` prevents hydration error
- Covers previously uncovered line 161 in `src/react.ts`

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs