### PR TITLE
test(proxyMap): add test for non-iterable initial entries error

### DIFF
--- a/tests/proxyMap.test.tsx
+++ b/tests/proxyMap.test.tsx
@@ -330,6 +330,12 @@ describe('proxyMap', () => {
     })
   })
 
+  it('should throw TypeError when initial entries is not iterable', () => {
+    expect(() => proxyMap(123 as any)).toThrow(
+      'proxyMap:\n\tinitial state must be iterable\n\t\ttip: structure should be [[key, value]]',
+    )
+  })
+
   describe('snapshot', () => {
     it('should error when trying to mutate a snapshot', () => {
       const state = proxyMap()


### PR DESCRIPTION
## Summary

- Add test case for `proxyMap` when initial entries is not iterable
- Verifies that `TypeError` is thrown with the correct error message
- Covers previously uncovered line 73 in `src/vanilla/utils/proxyMap.ts`

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs