### PR TITLE
fix(utils): prevent watch context leak across async callbacks

### DIFF
--- a/src/vanilla/utils/watch.ts
+++ b/src/vanilla/utils/watch.ts
@@ -75,12 +75,17 @@ export function watch(
 
     // Setup watch context, this allows us to automatically capture
     // watch cleanups if the watch callback itself has watch calls.
+    // Nested watches can only be created during the synchronous part of the
+    // callback, so the global context is restored right after the callback
+    // returns (before awaiting any returned promise). Keeping it set across
+    // the await would leak this watch's cleanups set into unrelated watches
+    // created while this one is suspended.
     const parent = currentCleanups
     currentCleanups = cleanups
 
-    // Ensures that the parent is reset if the callback throws an error.
+    let promiseOrPossibleCleanup: ReturnType<WatchCallback>
     try {
-      const promiseOrPossibleCleanup = callback((proxyObject) => {
+      promiseOrPossibleCleanup = callback((proxyObject) => {
         proxiesToSubscribe.add(proxyObject)
         // in case the callback is a promise and the watch has ended
         if (alive && !subscriptions.has(proxyObject)) {
@@ -90,21 +95,24 @@ export function watch(
         }
         return proxyObject
       })
-      const couldBeCleanup =
-        promiseOrPossibleCleanup && promiseOrPossibleCleanup instanceof Promise
-          ? await promiseOrPossibleCleanup
-          : promiseOrPossibleCleanup
-
-      // If there's a cleanup, we add this to the cleanups set
-      if (couldBeCleanup) {
-        if (alive) {
-          cleanups.add(couldBeCleanup)
-        } else {
-          cleanup()
-        }
-      }
     } finally {
+      // Restore the parent context before awaiting, so it is not corrupted by
+      // (or does not corrupt) revalidations that run while we are suspended.
       currentCleanups = parent
+    }
+
+    const couldBeCleanup =
+      promiseOrPossibleCleanup && promiseOrPossibleCleanup instanceof Promise
+        ? await promiseOrPossibleCleanup
+        : promiseOrPossibleCleanup
+
+    // If there's a cleanup, we add this to the cleanups set
+    if (couldBeCleanup) {
+      if (alive) {
+        cleanups.add(couldBeCleanup)
+      } else {
+        cleanup()
+      }
     }
 
     // Unsubscribe old subscriptions

--- a/tests/watch.test.tsx
+++ b/tests/watch.test.tsx
@@ -164,4 +164,43 @@ describe('watch', () => {
     await vi.advanceTimersByTimeAsync(10000)
     expect(callback).toBeCalledTimes(1)
   })
+
+  it('should not capture unrelated watches created while an async watch is pending (#1183)', async () => {
+    const A = proxy({ value: 0 })
+    const B = proxy({ value: 0 })
+
+    const cbA = vi.fn()
+    const cbB = vi.fn()
+
+    // watch1 is async and suspends at its await. While it is suspended, the
+    // shared watch context must not leak watch1's cleanups set.
+    watch(async (get) => {
+      get(A)
+      await sleep(1000)
+      cbA()
+    })
+
+    // While watch1 is suspended, create an independent watch2. Its cleanup
+    // must not be attached to watch1.
+    await vi.advanceTimersByTimeAsync(500)
+    watch((get) => {
+      get(B)
+      cbB()
+    })
+    expect(cbB).toBeCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(cbA).toBeCalledTimes(1)
+
+    // Trigger watch1 to revalidate, which runs its own cleanups. If watch2's
+    // cleanup had leaked into watch1, this would unsubscribe watch2.
+    A.value = 1
+    await vi.advanceTimersByTimeAsync(2000)
+
+    // watch2 must still react to B updates.
+    cbB.mockClear()
+    B.value = 1
+    await vi.advanceTimersByTimeAsync(0)
+    expect(cbB).toBeCalledTimes(1)
+  })
 })


### PR DESCRIPTION
## Summary

Fixes a context-leak bug in the `watch` util (reported in discussion [#1183](https://github.com/pmndrs/valtio/discussions/1183)) where a `watch` permanently stops reacting after an async update during another watch's initial async action.

`watch` uses a module-level `currentCleanups` set so that nested `watch` calls can attach their cleanup to the parent watch. The problem is that `revalidate` is `async` and keeps `currentCleanups` pointing at the current watch's `cleanups` set **across the `await`** of a promise-returning callback:

```ts
const parent = currentCleanups
currentCleanups = cleanups
try {
  const promiseOrPossibleCleanup = callback(/* ... */)
  const couldBeCleanup = ... ? await promiseOrPossibleCleanup : ...  // <- suspended here
  // ...
} finally {
  currentCleanups = parent   // <- only restored after the await resolves
}
```

While the first (async) watch is suspended at the `await`, the global is still set. Any **unrelated** `watch` created during that window (line `if (currentCleanups) currentCleanups.add(cleanup)`) gets its `cleanup` attached to the *first* watch's `cleanups` set. When the first watch later revalidates (`cleanups.forEach(clean => clean())`) or is cleaned up, it runs the unrelated watch's cleanup and unsubscribes it — so that watch silently stops reacting forever. This matches the reported symptom ("watch ends up deleting its own subscription"), and is especially easy to hit when an async action mutates a proxy during a watch's initial async callback.

## Fix

Nested watches can only register themselves during the **synchronous** part of the callback (line 121 runs while the parent callback is on the stack). So we restore the parent context immediately after the callback returns, *before* awaiting any returned promise. The global is therefore never left set across an `await`, and unrelated watches created while a watch is suspended are unaffected. Error-safety on the synchronous portion is preserved via `try/finally`.

This is a minimal change — no behavior change for nested-watch capture or promise watchers; only the leak across the await is removed.

## Test

Added a vanilla test (`tests/watch.test.tsx`) that:
1. starts an async watch that suspends at an `await`,
2. creates an independent watch while the first is suspended,
3. triggers the first watch to revalidate,
4. asserts the independent watch still reacts to its own proxy.

The test **fails on `main`** (`cbB` called 0 times after the revalidation) and **passes with this fix**. All existing tests pass (`pnpm test` — 286 passed, types + lint + prettier clean).

Refs #1183
